### PR TITLE
Autolaunch local game server

### DIFF
--- a/EvoS.Framework/EvosConfiguration.cs
+++ b/EvoS.Framework/EvosConfiguration.cs
@@ -11,6 +11,7 @@ namespace EvoS.Framework
         private static EvosConfiguration Instance = null;
         public int DirectoryServerPort = 6050;
         public int LobbyServerPort = 6060;
+        public string GameServerExecutable = "";
 
         private static EvosConfiguration GetInstance()
         {
@@ -33,6 +34,15 @@ namespace EvoS.Framework
         public static int GetLobbyServerPort()
         {
             return GetInstance().LobbyServerPort;
+        }
+
+        /// <summary>
+        /// Full path to server's "AtlasReactor.exe"
+        /// </summary>
+        /// <returns></returns>
+        public static string GetGameServerExecutable()
+        {
+            return GetInstance().GameServerExecutable;
         }
     }
 }

--- a/EvoS.Sandbox/Program.cs
+++ b/EvoS.Sandbox/Program.cs
@@ -22,12 +22,6 @@ namespace EvoS.Sandbox
         private void OnExecute()
         {
             Banner.PrintBanner();
-            Log.Print(LogType.Debug, "Asset folder hint: "+ System.Convert.ToString(Assets));
-            if (!AssetLoader.FindAssetRoot(Assets))
-            {
-                Log.Print(LogType.Error, "AtlasReactor_Data folder not found, please specify with --assets!");
-                Log.Print(LogType.Misc, "Alternatively, place Win64 or AtlasReactor_Data in this folder.");
-            }
 
             // Start Directory Server
             new Thread(() => StartDirServer()).Start();

--- a/LobbyServer2/BridgeServer/ServerManager.cs
+++ b/LobbyServer2/BridgeServer/ServerManager.cs
@@ -43,5 +43,14 @@ namespace CentralServer.BridgeServer
             
             return null;
         }
+
+        public static bool IsAnyServerAvailable()
+        {
+            foreach (BridgeServerProtocol server in ServerPool.Values)
+            {
+                if (server.IsAvailable()) return true;
+            }
+            return false;
+        }
     }
 }

--- a/LobbyServer2/CentralServer.cs
+++ b/LobbyServer2/CentralServer.cs
@@ -2,6 +2,7 @@
 using WebSocketSharp;
 using WebSocketSharp.Server;
 using EvoS.Framework;
+using EvoS.Framework.Logging;
 
 namespace CentralServer
 {
@@ -9,15 +10,22 @@ namespace CentralServer
     {
         public static void Main(string[] args)
         {
-            WebSocketServer server = new WebSocketServer(EvosConfiguration.GetLobbyServerPort());
+            int port = EvosConfiguration.GetLobbyServerPort();
+            WebSocketServer server = new WebSocketServer(port);
             server.AddWebSocketService<LobbyServer.LobbyServerProtocol>("/LobbyGameClientSessionManager");
             server.AddWebSocketService<BridgeServer.BridgeServerProtocol>("/BridgeServer");
             server.Log.Level = LogLevel.Debug;
 
 
             server.Start();
-            Console.WriteLine("Lobby server started");
+            Log.Print(LogType.Lobby, $"Started lobby server on port {port}");
+            if (EvosConfiguration.GetGameServerExecutable().IsNullOrEmpty())
+            {
+                Log.Print(LogType.Warning, "GameServerExecutable not set in settings.yaml");
+                Log.Print(LogType.Warning, "Automatic game server launch is disabled. Game servers can still connect to this lobby");
+            }
             Console.ReadLine();
+            
             //Console.ReadKey();
             //server.Stop();
         }

--- a/LobbyServer2/CentralServer.csproj
+++ b/LobbyServer2/CentralServer.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
@@ -20,6 +20,12 @@
   </ItemGroup>
 
   <ItemGroup>
+    <None Update="Config\GameSubTypes\1v1PvP.json">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+    <None Update="Config\GameSubTypes\GenericPvP.json">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
     <None Update="settings.yaml">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>

--- a/LobbyServer2/Config/GameSubTypes/1v1PvP.json
+++ b/LobbyServer2/Config/GameSubTypes/1v1PvP.json
@@ -1,0 +1,37 @@
+{
+  "LocalizedName": "1v1PvP@SubTypes",
+  "GameMapConfigs": [
+    {
+      "Map": "Skyway_Deathmatch",
+      "IsActive": true
+    }
+  ],
+  "TeamAPlayers": 1,
+  "TeamBPlayers": 1,
+  "TeamABots": 0,
+  "TeamBBots": 0,
+  "TeamComposition": {
+    "Rules": {
+      "A1": {
+        "Roles": [
+          "Tank",
+          "Assassin",
+          "Support"
+        ]
+      },
+      "B1": {
+        "Roles": [
+          "Tank",
+          "Assassin",
+          "Support"
+        ]
+      }
+    }
+  },
+  "RewardBucket": "NoRewards",
+  "PersistedStatBucket": "DoNotPersist",
+  "Mods": [
+    "AllowPlayingLockedCharacters",
+    "HumansHaveFirstSlots"
+  ]
+}

--- a/LobbyServer2/Config/GameSubTypes/GenericPvP.json
+++ b/LobbyServer2/Config/GameSubTypes/GenericPvP.json
@@ -1,0 +1,37 @@
+{
+  "LocalizedName": "GenericPvP@SubTypes",
+  "GameMapConfigs": [
+    {
+      "Map": "Skyway_Deathmatch",
+      "IsActive": true
+    }
+  ],
+  "TeamAPlayers": 4,
+  "TeamBPlayers": 4,
+  "TeamABots": 0,
+  "TeamBBots": 0,
+  "TeamComposition": {
+    "Rules": {
+      "A1": {
+        "Roles": [
+          "Tank",
+          "Assassin",
+          "Support"
+        ]
+      },
+      "B1": {
+        "Roles": [
+          "Tank",
+          "Assassin",
+          "Support"
+        ]
+      }
+    }
+  },
+  "RewardBucket": "NoRewards",
+  "PersistedStatBucket": "DoNotPersist",
+  "Mods": [
+    "AllowPlayingLockedCharacters",
+    "HumansHaveFirstSlots"
+  ]
+}

--- a/LobbyServer2/LobbyServer/Config/Messages.cs
+++ b/LobbyServer2/LobbyServer/Config/Messages.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Text;
 

--- a/LobbyServer2/LobbyServer/GameMode/GameModeManager.cs
+++ b/LobbyServer2/LobbyServer/GameMode/GameModeManager.cs
@@ -5,6 +5,8 @@ using CentralServer.LobbyServer.Config;
 using System;
 using System.Collections.Generic;
 using System.Text;
+using Newtonsoft.Json;
+using System.IO;
 
 namespace CentralServer.LobbyServer.Gamemode
 {
@@ -103,51 +105,26 @@ namespace CentralServer.LobbyServer.Gamemode
             type.MaxWillFillPerTeam = 0;
             type.SubTypes = new List<GameSubType>()
             {
-                new GameSubType
-                {
-                    LocalizedName = "GenericPvP@SubTypes",
-                    GameMapConfigs = new List<GameMapConfig>{ new GameMapConfig(Maps.Skyway_Deathmatch, true) },
-                    RewardBucket = GameBalanceVars.GameRewardBucketType.NoRewards,
-                    PersistedStatBucket = PersistedStatBucket.DoNotPersist,
-                    TeamAPlayers = 1,
-                    TeamABots = 0,
-                    TeamBPlayers = 1,
-                    TeamBBots = 0,
-                    Mods = new List<GameSubType.SubTypeMods>
-                    {
-                        GameSubType.SubTypeMods.AllowPlayingLockedCharacters,
-                        GameSubType.SubTypeMods.HumansHaveFirstSlots
-                    },
-                    TeamComposition = new TeamCompositionRules
-                    {
-                        Rules = new Dictionary<TeamCompositionRules.SlotTypes, FreelancerSet>
-                        {
-                            {
-                                TeamCompositionRules.SlotTypes.A1, new FreelancerSet
-                                {
-                                    Roles = new List<CharacterRole>
-                                    {
-                                        CharacterRole.Tank,
-                                        CharacterRole.Assassin,
-                                        CharacterRole.Support
-                                    }
-                                }
-                            }, {
-                                TeamCompositionRules.SlotTypes.B1, new FreelancerSet
-                                {
-                                    Roles = new List<CharacterRole>
-                                    {
-                                        CharacterRole.Tank,
-                                        CharacterRole.Assassin,
-                                        CharacterRole.Support
-                                    }
-                                }
-                            }
-                        }
-                    }
-                }
+                LoadGameSubType("1v1PvP.json")
+                //LoadGameSubType("GenericPvP.json")
             };
             return type;
+        }
+
+        /// <summary>
+        /// Reads a json file that represents a GameSubType
+        /// </summary>
+        /// <param name="filename">File name inside the folder 'Config/GameSubTypes/'</param>
+        /// <returns>A GameSubType loaded from the file</returns>
+        private static GameSubType LoadGameSubType(string filename)
+        {
+            // TODO: this always read from file, it could be stored in a cache
+            JsonReader reader = new JsonTextReader(new StreamReader(@"Config\GameSubTypes\" + filename));
+            try
+            {
+                return new JsonSerializer().Deserialize<GameSubType>(reader);
+            }
+            finally { reader.Close(); }
         }
 
         private static GameTypeAvailability GetRankedGameTypeAvailability()

--- a/LobbyServer2/LobbyServer/LobbyServerProtocol.cs
+++ b/LobbyServer2/LobbyServer/LobbyServerProtocol.cs
@@ -1,4 +1,4 @@
-﻿using CentralServer.LobbyServer.Account;
+using CentralServer.LobbyServer.Account;
 using CentralServer.LobbyServer.Friend;
 using CentralServer.LobbyServer.Matchmaking;
 using CentralServer.LobbyServer.Session;
@@ -256,24 +256,13 @@ namespace CentralServer.LobbyServer
 
         public void HandleJoinMatchmakingQueueRequest(JoinMatchmakingQueueRequest request)
         {
-            Console.WriteLine("JoinMatchmakingQueueRequest " + JsonConvert.SerializeObject(request));
+            Log.Print(LogType.Lobby, $"{this.UserName} joined {request.GameType} queue ");
 
-            /*
-            LeaveGameResponse response = new LeaveGameResponse()
-            {
-                Success = true,
-                ResponseId = request.RequestId
-            };
-            Send(response);*/
+            // Send response to the calling request
+            Send(new JoinMatchmakingQueueResponse { LocalizedFailure = null, ResponseId = request.RequestId });
 
-            LobbyMatchmakingQueueInfo queueInfo = MatchmakingManager.AddToQueue(request.GameType, this);
-            MatchmakingQueueAssignmentNotification assignmentNotification = new MatchmakingQueueAssignmentNotification()
-            {
-                MatchmakingQueueInfo = queueInfo
-            };
-            Send(assignmentNotification);
-
-            Send(new JoinMatchmakingQueueResponse { LocalizedFailure = null, ResponseId = request.RequestId});
+            // Add player to the selected queue
+            MatchmakingManager.AddToQueue(request.GameType, this);
         }
 
         public void HandleLeaveMatchmakingQueueRequest(LeaveMatchmakingQueueRequest request)

--- a/LobbyServer2/LobbyServer/LobbyServerProtocolBase.cs
+++ b/LobbyServer2/LobbyServer/LobbyServerProtocolBase.cs
@@ -52,7 +52,9 @@ namespace CentralServer.LobbyServer
                 EvosMessageDelegate<WebSocketMessage> handler = GetHandler(deserialized.GetType());
                 if (handler != null)
                 {
+                    #if DEBUG
                     Log.Print(LogType.Network, "Received " + deserialized.GetType().Name);
+                    #endif
                     handler.Invoke(deserialized);
                 }
                 else

--- a/LobbyServer2/settings.yaml
+++ b/LobbyServer2/settings.yaml
@@ -1,2 +1,3 @@
 ﻿DirectoryServerPort: 6050
 LobbyServerPort: 6060
+GameServerExecutable: ""


### PR DESCRIPTION
When a match can be started by quantity of players, and if the path to a server's .exe is configured in settings.yaml, the lobby server will start a server and when it connects, the matchmaking queue will update again to send the players to the loading screen