### PR TITLE
End Game Screen

### DIFF
--- a/EvoS.Framework/Misc/ServerGameMetrics.cs
+++ b/EvoS.Framework/Misc/ServerGameMetrics.cs
@@ -1,0 +1,19 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace EvoS.Framework.Misc
+{
+    [Serializable]
+    public class ServerGameMetrics
+    {
+        public int CurrentTurn;
+
+        public int TeamAPoints;
+
+        public int TeamBPoints;
+
+        public float AverageFrameTime;
+    }
+
+}

--- a/EvoS.Framework/Network/Static/LobbyPlayerInfo.cs
+++ b/EvoS.Framework/Network/Static/LobbyPlayerInfo.cs
@@ -15,7 +15,7 @@ namespace EvoS.Framework.Network.Static
 
         public bool ReplacedWithBots { get; set; }
 
-        public static LobbyPlayerInfo FromServer(LobbyServerPlayerInfo serverInfo, int maxPlayerLevel,
+        public static LobbyPlayerInfo FromServer(LobbyServerPlayerInfo serverInfo,
             MatchmakingQueueConfig queueConfig)
         {
             LobbyPlayerInfo lobbyPlayerInfo = null;
@@ -57,22 +57,6 @@ namespace EvoS.Framework.Network.Static
                         ((!serverInfo.IsRemoteControlled) ? 0 : serverInfo.ControllingPlayerInfo.PlayerId),
                     EffectiveClientAccessLevel = serverInfo.EffectiveClientAccessLevel
                 };
-                if (serverInfo.AccountLevel >= maxPlayerLevel)
-                {
-//                    lobbyPlayerInfo.DisplayedStat = LocalizationPayload.Create("TotalSeasonLevelStatNumber", "Global",
-//                        new LocalizationArg[]
-//                        {
-//                            LocalizationArg_Int32.Create(serverInfo.TotalLevel)
-//                        });
-                }
-                else
-                {
-//                    lobbyPlayerInfo.DisplayedStat = LocalizationPayload.Create("LevelStatNumber", "Global",
-//                        new LocalizationArg[]
-//                        {
-//                            LocalizationArg_Int32.Create(serverInfo.AccountLevel)
-//                        });
-                }
             }
 
             return lobbyPlayerInfo;

--- a/EvoS.Framework/Network/Static/LobbyTeamInfo.cs
+++ b/EvoS.Framework/Network/Static/LobbyTeamInfo.cs
@@ -35,7 +35,7 @@ namespace EvoS.Framework.Network.Static
                 select p;
         }
 
-        public static LobbyTeamInfo FromServer(LobbyServerTeamInfo serverInfo, int maxPlayerLevel,
+        public static LobbyTeamInfo FromServer(LobbyServerTeamInfo serverInfo,
             MatchmakingQueueConfig queueConfig)
         {
             LobbyTeamInfo lobbyTeamInfo = null;
@@ -47,8 +47,7 @@ namespace EvoS.Framework.Network.Static
                     lobbyTeamInfo.TeamPlayerInfo = new List<LobbyPlayerInfo>();
                     foreach (LobbyServerPlayerInfo serverInfo2 in serverInfo.TeamPlayerInfo)
                     {
-                        lobbyTeamInfo.TeamPlayerInfo.Add(LobbyPlayerInfo.FromServer(serverInfo2, maxPlayerLevel,
-                            queueConfig));
+                        lobbyTeamInfo.TeamPlayerInfo.Add(LobbyPlayerInfo.FromServer(serverInfo2, queueConfig));
                     }
                 }
             }

--- a/LobbyServer2/BridgeServer/BridgeServerProtocol.cs
+++ b/LobbyServer2/BridgeServer/BridgeServerProtocol.cs
@@ -112,10 +112,8 @@ namespace CentralServer.BridgeServer
             else if (type == typeof(ServerGameSummaryNotification))
             {
                 ServerGameSummaryNotification request = Deserialize<ServerGameSummaryNotification>(networkReader);
-                log.Info("Game Summary notification");
-                log.Info(request.ToJson());
 
-                log.Info($"< {request.GetType().Name} {DefaultJsonSerializer.Serialize(request)}");
+                log.Debug($"< {request.GetType().Name} {DefaultJsonSerializer.Serialize(request)}");
                 log.Info($"Game {GameInfo.Name} finished ");
 
                 List<BadgeAndParticipantInfo> badges;
@@ -181,7 +179,10 @@ namespace CentralServer.BridgeServer
             else if (type == typeof(ServerGameMetricsNotification))
             {
                 ServerGameMetricsNotification request = Deserialize<ServerGameMetricsNotification>(networkReader);
-                log.Info($"Game {GameInfo.Name} is on turn {request.CurrentTurn} with score {request.TeamAPoints}/{request.TeamBPoints}");
+                if (request.GameMetrics != null)
+                {
+                    log.Debug($"Game {GameInfo.Name} is on turn {request.GameMetrics.CurrentTurn} with score {request.GameMetrics.TeamAPoints}/{request.GameMetrics.TeamBPoints}");
+                }
             }
             else
             {
@@ -287,7 +288,11 @@ namespace CentralServer.BridgeServer
 
             foreach (long player in GetPlayers())
             {
-                SessionManager.GetClientConnection(player).Send(notification);
+                LobbyServerProtocol playerConnection = SessionManager.GetClientConnection(player);
+                if (playerConnection != null)
+                {
+                    playerConnection.Send(notification);
+                }
             }
         }
 
@@ -301,7 +306,11 @@ namespace CentralServer.BridgeServer
                     TeamInfo = LobbyTeamInfo.FromServer(this.TeamInfo, new MatchmakingQueueConfig()),
                     PlayerInfo = LobbyPlayerInfo.FromServer(SessionManager.GetPlayerInfo(player), new MatchmakingQueueConfig()) 
                 };
-                SessionManager.GetClientConnection(player).Send(notification);
+                LobbyServerProtocol playerConnection = SessionManager.GetClientConnection(player);
+                if (playerConnection != null)
+                {
+                    playerConnection.Send(notification);
+                }
             }
         }
 

--- a/LobbyServer2/BridgeServer/BridgeServerProtocol.cs
+++ b/LobbyServer2/BridgeServer/BridgeServerProtocol.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Reflection;
@@ -10,6 +10,7 @@ using EvoS.Framework.Network.NetworkMessages;
 using EvoS.Framework.Network.Static;
 using EvoS.Framework.Network.Unity;
 using log4net;
+using MongoDB.Bson;
 using WebSocketSharp;
 using WebSocketSharp.Server;
 
@@ -56,7 +57,7 @@ namespace CentralServer.BridgeServer
             null, // typeof(MonitorHeartbeatResponse),
             typeof(ServerGameSummaryNotification),
             typeof(PlayerDisconnectedNotification),
-            null, // typeof(ServerGameMetricsNotification),
+            typeof(ServerGameMetricsNotification),
             typeof(ServerGameStatusNotification),
             null, // typeof(MonitorHeartbeatNotification),
             null, // typeof(LaunchGameResponse),

--- a/LobbyServer2/BridgeServer/Messages/ServerGameMetricsNotification.cs
+++ b/LobbyServer2/BridgeServer/Messages/ServerGameMetricsNotification.cs
@@ -1,4 +1,6 @@
-﻿using System;
+﻿using EvoS.Framework.Misc;
+using EvoS.Framework.Network.Unity;
+using System;
 using System.Collections.Generic;
 using System.Text;
 
@@ -6,12 +8,19 @@ using System.Text;
 [Serializable]
 public class ServerGameMetricsNotification : AllianceMessageBase
 {
-    public int CurrentTurn;
+    public ServerGameMetrics GameMetrics;
 
-    public int TeamAPoints;
+    public override void Serialize(NetworkWriter writer)
+    {
+        base.Serialize(writer);
+        SerializeObject(GameMetrics, writer);
+    }
 
-    public int TeamBPoints;
 
-    public float AverageFrameTime;
+    public override void Deserialize(NetworkReader reader)
+    {
+        base.Deserialize(reader);
+        DeserializeObject(out GameMetrics, reader);
+    }
 }
 

--- a/LobbyServer2/BridgeServer/Messages/ServerGameMetricsNotification.cs
+++ b/LobbyServer2/BridgeServer/Messages/ServerGameMetricsNotification.cs
@@ -1,0 +1,17 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+
+
+[Serializable]
+public class ServerGameMetricsNotification : AllianceMessageBase
+{
+    public int CurrentTurn;
+
+    public int TeamAPoints;
+
+    public int TeamBPoints;
+
+    public float AverageFrameTime;
+}
+

--- a/LobbyServer2/LobbyServer/LobbyServerProtocol.cs
+++ b/LobbyServer2/LobbyServer/LobbyServerProtocol.cs
@@ -406,14 +406,7 @@ namespace CentralServer.LobbyServer
 
             if (CurrentServer != null)
             {
-                CurrentServer.clients.Remove(this);
-                GameStatusNotification notify = new GameStatusNotification()
-                {
-                    GameServerProcessCode = CurrentServer.ProcessCode,
-                    GameStatus = GameStatus.Stopped // TODO check if there is a better way to make client leave mid-game
-                };
-                Send(notify);
-                CurrentServer = null; // we will probably want to save it somewhere for reconnection
+                CurrentServer.OnPlayerDisconnected(AccountId);
             }
         }
         
@@ -777,6 +770,8 @@ namespace CentralServer.LobbyServer
                         client.Send(useGGPackNotification);
                     }
                 }
+
+                CurrentServer.OnPlayerUsedGGPack(AccountId);
             }
         }
 

--- a/LobbyServer2/LobbyServer/LobbyServerProtocol.cs
+++ b/LobbyServer2/LobbyServer/LobbyServerProtocol.cs
@@ -329,7 +329,7 @@ namespace CentralServer.LobbyServer
             
             PlayerInfoUpdateResponse response = new PlayerInfoUpdateResponse()
             {
-                PlayerInfo = LobbyPlayerInfo.FromServer(playerInfo, 0, new MatchmakingQueueConfig()),
+                PlayerInfo = LobbyPlayerInfo.FromServer(playerInfo, new MatchmakingQueueConfig()),
                 CharacterInfo = playerInfo.CharacterInfo,
                 OriginalPlayerInfoUpdate = update,
                 ResponseId = request.RequestId

--- a/LobbyServer2/LobbyServer/Matchmaking/MatchmakingManager.cs
+++ b/LobbyServer2/LobbyServer/Matchmaking/MatchmakingManager.cs
@@ -169,7 +169,7 @@ namespace CentralServer.LobbyServer.Matchmaking
                     GameInfo = practiceGameInfo,
                     GameResult = GameResult.NoResult,
                     Observer = false,
-                    PlayerInfo = LobbyPlayerInfo.FromServer(teamInfo.TeamPlayerInfo[0], 0, queueConfig),
+                    PlayerInfo = LobbyPlayerInfo.FromServer(teamInfo.TeamPlayerInfo[0], queueConfig),
                     Reconnection = false,
                     GameplayOverrides = client.GetGameplayOverrides()
                 };
@@ -179,9 +179,9 @@ namespace CentralServer.LobbyServer.Matchmaking
                 practiceGameInfo.GameStatus = GameStatus.Launched;
                 GameInfoNotification notification2 = new GameInfoNotification()
                 {
-                    TeamInfo = LobbyTeamInfo.FromServer(teamInfo, 0, queueConfig),
+                    TeamInfo = LobbyTeamInfo.FromServer(teamInfo, queueConfig),
                     GameInfo = practiceGameInfo,
-                    PlayerInfo = LobbyPlayerInfo.FromServer(teamInfo.TeamPlayerInfo[0], 0, queueConfig)
+                    PlayerInfo = LobbyPlayerInfo.FromServer(teamInfo.TeamPlayerInfo[0], queueConfig)
                 };
 
                 client.Send(notification2);
@@ -197,6 +197,8 @@ namespace CentralServer.LobbyServer.Matchmaking
             GameSubType subType = lobbyQueue.MatchmakingQueueInfo.GameConfig.SubTypes[0];
             LobbyServerTeamInfo teamInfo = new LobbyServerTeamInfo { TeamPlayerInfo = new List<LobbyServerPlayerInfo>() };
             List<LobbyServerProtocol> clients = new List<LobbyServerProtocol>();
+
+
             // Fill team A
             foreach (long accountId in teamA)
             {
@@ -213,7 +215,6 @@ namespace CentralServer.LobbyServer.Matchmaking
                 log.Info($"adding player {client.UserName}, {client.AccountId} to team A");
                 teamInfo.TeamPlayerInfo.Add(playerInfo);
             }
-
             // Fill team B
             foreach (long accountId in teamB)
             {
@@ -263,49 +264,48 @@ namespace CentralServer.LobbyServer.Matchmaking
                 log.Info($"No available server for {gameType} gamemode");
                 return;
             }
-            else
+            
+            server.clients = clients;
+            gameInfo.GameServerAddress = server.URI;
+            gameInfo.GameServerProcessCode = server.ProcessCode;
+            gameInfo.GameStatus = GameStatus.Launching;
+
+            for (int i = 0; i < clients.Count; i++)
             {
-                server.clients = clients;
-                gameInfo.GameServerAddress = server.URI;
-                gameInfo.GameServerProcessCode = server.ProcessCode;
-                gameInfo.GameStatus = GameStatus.Launching;
-
-                for (int i = 0; i < clients.Count; i++)
+                LobbyServerProtocol client = clients[i];
+                GameAssignmentNotification notification = new GameAssignmentNotification
                 {
-                    LobbyServerProtocol client = clients[i];
-                    GameAssignmentNotification notification = new GameAssignmentNotification
-                    {
-                        GameInfo = gameInfo,
-                        GameResult = GameResult.NoResult,
-                        Observer = false,
-                        PlayerInfo = LobbyPlayerInfo.FromServer(teamInfo.TeamPlayerInfo[i], 0, queueConfig),
-                        Reconnection = false,
-                        GameplayOverrides = client.GetGameplayOverrides()
-                    };
-
-                    client.Send(notification);
-                    client.CurrentServer = server;
-                }
-
-                gameInfo.GameStatus = GameStatus.Launched;
-
-                for (int i = 0; i < clients.Count; i++)
-                {
-                    LobbyServerProtocolBase client = clients[i];
-                    GameInfoNotification notification = new GameInfoNotification()
-                    {
-                        TeamInfo = LobbyTeamInfo.FromServer(teamInfo, 0, queueConfig),
-                        GameInfo = gameInfo,
-                        PlayerInfo = LobbyPlayerInfo.FromServer(teamInfo.TeamPlayerInfo[i], 0, queueConfig)
-                    };
-
-                    client.Send(notification);
-                }
-
-                clients.ForEach(c => c.OnStartGame());
-
-                log.Info($"Game {gameType} started");
+                    GameInfo = gameInfo,
+                    GameResult = GameResult.NoResult,
+                    Observer = false,
+                    PlayerInfo = LobbyPlayerInfo.FromServer(teamInfo.TeamPlayerInfo[i], queueConfig),
+                    Reconnection = false,
+                    GameplayOverrides = client.GetGameplayOverrides()
+                };
+                
+                client.Send(notification);
+                client.CurrentServer = server;
             }
+
+            gameInfo.GameStatus = GameStatus.Launched;
+
+            for (int i = 0; i < clients.Count; i++)
+            {
+                LobbyServerProtocolBase client = clients[i];
+                GameInfoNotification notification = new GameInfoNotification()
+                {
+                    TeamInfo = LobbyTeamInfo.FromServer(teamInfo, queueConfig),
+                    GameInfo = gameInfo,
+                    PlayerInfo = LobbyPlayerInfo.FromServer(teamInfo.TeamPlayerInfo[i], queueConfig)
+                };
+                
+                client.Send(notification);
+            }
+
+            clients.ForEach(c => c.OnStartGame());
+
+            log.Info($"Game {gameType} started");
+            
         }
 
         public static void StartGameVBots(List<LobbyServerProtocolBase> clients, GameType gameType)
@@ -375,7 +375,7 @@ namespace CentralServer.LobbyServer.Matchmaking
                         GameInfo = gameInfo,
                         GameResult = GameResult.NoResult,
                         Observer = false,
-                        PlayerInfo = LobbyPlayerInfo.FromServer(teamInfo.TeamPlayerInfo[i], 0, queueConfig),
+                        PlayerInfo = LobbyPlayerInfo.FromServer(teamInfo.TeamPlayerInfo[i], queueConfig),
                         Reconnection = false,
                         GameplayOverrides = client.GetGameplayOverrides()
                     };
@@ -390,9 +390,9 @@ namespace CentralServer.LobbyServer.Matchmaking
                     LobbyServerProtocolBase client = clients[i];
                     GameInfoNotification notification = new GameInfoNotification()
                     {
-                        TeamInfo = LobbyTeamInfo.FromServer(teamInfo, 0, queueConfig),
+                        TeamInfo = LobbyTeamInfo.FromServer(teamInfo, queueConfig),
                         GameInfo = gameInfo,
-                        PlayerInfo = LobbyPlayerInfo.FromServer(teamInfo.TeamPlayerInfo[i], 0, queueConfig)
+                        PlayerInfo = LobbyPlayerInfo.FromServer(teamInfo.TeamPlayerInfo[i], queueConfig)
                     };
 
                     client.Send(notification);


### PR DESCRIPTION
- Clients now received the MatchResultsNotification even if the game servers sends a null GameSummary
- Added register and processing of ServerGameMetricsNotification (notify's current turn and score, seems to receive null from the game server)
- Lobby no longer sends a shutdown notification when it receives the game summary (because the clients that doesn't press Exit before the server shutdowns get stuck in this screen)
- Now if there is no more players in the server, the lobby sends a shutdown request to stop the server