### PR TITLE
Queue Impromevements part 1 - Antilock for mixed solo players and groups

### DIFF
--- a/EvoS.Framework/Network/Static/LobbyMatchmakingQueueInfo.cs
+++ b/EvoS.Framework/Network/Static/LobbyMatchmakingQueueInfo.cs
@@ -7,12 +7,19 @@ namespace EvoS.Framework.Network.Static
     [EvosMessage(744)]
     public class LobbyMatchmakingQueueInfo
     {
+        public bool ShowQueueSize;
+        public int QueuedPlayers;
+        public float PlayersPerMinute;
+        public TimeSpan AverageWaitTime = TimeSpan.FromMinutes(5.0);
+        public LobbyGameConfig GameConfig;
+        public QueueStatus QueueStatus;
+
+        public GameType GameType => GameConfig?.GameType ?? GameType.None;
+
         public override string ToString()
         {
             return (GameConfig != null) ? GameConfig.ToString() : "unknown";
         }
-
-        public GameType GameType => GameConfig?.GameType ?? GameType.None;
 
         public LobbyMatchmakingQueueInfo Clone()
         {
@@ -76,11 +83,6 @@ namespace EvoS.Framework.Network.Static
             }
         }
 
-        public bool ShowQueueSize;
-        public int QueuedPlayers;
-        public float PlayersPerMinute;
-        public TimeSpan AverageWaitTime = TimeSpan.FromMinutes(5.0);
-        public LobbyGameConfig GameConfig;
-        public QueueStatus QueueStatus;
+        
     }
 }

--- a/LobbyServer2/LobbyServer/Matchmaking/MatchmakingGroupInfo.cs
+++ b/LobbyServer2/LobbyServer/Matchmaking/MatchmakingGroupInfo.cs
@@ -1,0 +1,23 @@
+﻿using CentralServer.LobbyServer.Group;
+using EvoS.Framework.Constants.Enums;
+using EvoS.Framework.Misc;
+using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace CentralServer.LobbyServer.Matchmaking
+{
+    internal class MatchmakingGroupInfo
+    {
+        public int GroupID;
+        public int Players;
+        public Team Team;
+
+        public MatchmakingGroupInfo(int groupID)
+        {
+            GroupID = groupID;
+            Players = GroupManager.GetGroup(groupID).Members.Count;
+            Team = Team.Invalid;
+        }
+    }
+}

--- a/LobbyServer2/LobbyServer/Matchmaking/MatchmakingManager.cs
+++ b/LobbyServer2/LobbyServer/Matchmaking/MatchmakingManager.cs
@@ -21,6 +21,7 @@ namespace CentralServer.LobbyServer.Matchmaking
     public static class MatchmakingManager
     {
         private static readonly ILog log = LogManager.GetLogger(typeof(MatchmakingManager));
+        private static readonly object queueUpdateRunning = new object();
         
         // List of matchmaking queues by game mode (practive, coop, pvp, ranked and custom)
         private static Dictionary<GameType, MatchmakingQueue> Queues = new Dictionary<GameType, MatchmakingQueue>()
@@ -37,10 +38,14 @@ namespace CentralServer.LobbyServer.Matchmaking
         /// </summary>
         public static void Update()
         {
-            foreach (var queue in Queues.Values)
+            lock (queueUpdateRunning)
             {
-                queue.Update();
+                foreach (var queue in Queues.Values)
+                {
+                    queue.Update();
+                }
             }
+            
         }
 
         /// <summary>

--- a/LobbyServer2/LobbyServer/Matchmaking/MatchmakingQueue.cs
+++ b/LobbyServer2/LobbyServer/Matchmaking/MatchmakingQueue.cs
@@ -96,9 +96,6 @@ namespace CentralServer.LobbyServer.Matchmaking
             foreach (GameSubType subType in MatchmakingQueueInfo.GameConfig.SubTypes)
             {
                 List<MatchmakingGroupInfo> groups = new List<MatchmakingGroupInfo>();
-                
-                int requiredPlayers = subType.TeamAPlayers + subType.TeamBPlayers;
-                int playersInGroups = 0;
 
                 lock (GroupManager.Lock)
                 {

--- a/LobbyServer2/LobbyServer/Matchmaking/MatchmakingQueue.cs
+++ b/LobbyServer2/LobbyServer/Matchmaking/MatchmakingQueue.cs
@@ -95,37 +95,42 @@ namespace CentralServer.LobbyServer.Matchmaking
 
             foreach (GameSubType subType in MatchmakingQueueInfo.GameConfig.SubTypes)
             {
-                // full greed for now
+                List<MatchmakingGroupInfo> groups = new List<MatchmakingGroupInfo>();
+                
+                int requiredPlayers = subType.TeamAPlayers + subType.TeamBPlayers;
+                int playersInGroups = 0;
+
                 lock (GroupManager.Lock)
                 {
-                    List<GroupInfo> groups = QueuedGroups.Keys
-                        .Select(GroupManager.GetGroup)
-                        .Where(group => group != null)
-                        .ToList();
-                    List<GroupInfo> teamA = new List<GroupInfo>();
-                    List<GroupInfo> teamB = new List<GroupInfo>();
-                    int teamANum = 0;
-                    int teamBNum = 0;
-                    foreach (GroupInfo group in groups)
+                    bool success = false;
+                    // TODO: this add teams one by one until it has enough to form a game, QueuedGroups is a Dictionary
+                    // so Keys might be unsorted (no guarantee of oldest player in queue will find a game first)
+                    foreach (int groupId in QueuedGroups.Keys)
                     {
-                        if (teamANum + group.Members.Count <= subType.TeamAPlayers)
-                        {
-                            teamANum += group.Members.Count;
-                            teamA.Add(group);
-                        }
-                        else if (teamBNum + group.Members.Count <= subType.TeamBPlayers)
-                        {
-                            teamBNum += group.Members.Count;
-                            teamB.Add(group);
-                        }
-                        if (teamANum == subType.TeamAPlayers && teamBNum == subType.TeamBPlayers)
-                        {
-                            break;
-                        }
+                        // Add new groups secuentially
+                        MatchmakingGroupInfo currentGroup = new MatchmakingGroupInfo(groupId);
+                        groups.Add(currentGroup);
+                        success = TryFormTeams(subType, ref groups);
+                        if (success) break;
                     }
 
-                    if (teamANum == subType.TeamAPlayers && teamBNum == subType.TeamBPlayers)
+                    if (success)
                     {
+                        List<GroupInfo> teamA = new List<GroupInfo>();
+                        List<GroupInfo> teamB = new List<GroupInfo>();
+
+                        foreach (MatchmakingGroupInfo group in groups)
+                        {
+                            if (group.Team == Team.TeamA)
+                            {
+                                teamA.Add(GroupManager.GetGroup(group.GroupID));
+                            }
+                            else if (group.Team == Team.TeamB)
+                            {
+                                teamB.Add(GroupManager.GetGroup(group.GroupID));
+                            }
+                        }
+
                         if (!CheckGameServerAvailable())
                         {
                             log.Warn("No available game server to start a match");
@@ -147,6 +152,69 @@ namespace CentralServer.LobbyServer.Matchmaking
                     }
                 }
             }
+        }
+
+        /// <summary>
+        /// Tries to form a team with the list of groups specified. The teams are not balanced at all. it just looks for group size
+        /// </summary>
+        /// <param name="subType">GameSubtype of the game we are trying to make</param>
+        /// <param name="matchmakingGroups">available groups to form a team</param>
+        /// <returns>true if a team was formed, otherwise returns false</returns>
+        private static bool TryFormTeams(GameSubType subType, ref List<MatchmakingGroupInfo> matchmakingGroups)
+        {
+            bool success = false;
+            int teamANum = GetPlayersInTeam(Team.TeamA, matchmakingGroups);
+            int teamBNum = GetPlayersInTeam(Team.TeamB, matchmakingGroups);
+
+            // Full team? Success!
+            if (teamANum == subType.TeamAPlayers && teamBNum == subType.TeamBPlayers) return true;
+
+            foreach (MatchmakingGroupInfo group in matchmakingGroups)
+            {
+                // Team Invalid is used as "no team asigned"
+                if (group.Team != Team.Invalid) continue;
+
+                // Try to place the team either in Team A or B
+                if (teamANum + group.Players <= subType.TeamAPlayers)
+                {
+                    group.Team = Team.TeamA;
+                }
+                else if (teamBNum + group.Players <= subType.TeamBPlayers)
+                {
+                    group.Team = Team.TeamB;
+                }
+
+                // If a team was assigned for this group, we try recursion to assign a new group
+                if(group.Team != Team.Invalid)
+                {
+                    success = TryFormTeams(subType, ref matchmakingGroups);
+                    if (success) return true;
+
+                    // If we couln't form a match, this team is assigned as invalid for next iteration
+                    group.Team = Team.Invalid;
+                }
+            }
+            return success;
+        }
+
+        /// <summary>
+        /// Counts how many players are in the groups list that are assigned to the specified team
+        /// </summary>
+        /// <param name="team"></param>
+        /// <param name="groups"></param>
+        /// <returns>number of player in team</returns>
+        private static int GetPlayersInTeam(Team team, List<MatchmakingGroupInfo> groups)
+        {
+            int count = 0;
+            foreach (MatchmakingGroupInfo groupInfo in groups)
+            {
+                if (groupInfo.Team == team)
+                {
+                    count += groupInfo.Players;
+                }
+            }
+
+            return count;
         }
 
         public bool CheckGameServerAvailable()


### PR DESCRIPTION
- Avoid running more than one queue update at once
- Changes in the way the teams are formed in the queue:

Now when the queue tries to make a game, it iterates recursively all the possible group combinations until it is able to make a team. Note: Teams formed are still unbalanced (it doesn't check for freelancer type to make the teams, i'll look into that in future versions)

Before it was possible to have enough players to form a group but the queue fails because the slot was ocuppied.

i.e:
Team A: 1 group of 4 players
Team B: 1 group of 1 players
unassigned groups: 1 of 4 players.

in this case one slot of Team B was taken but it was possible to make a game with the other group of 4 people