### PR TITLE
End of match stats screen stuff

### DIFF
--- a/LobbyServer2/LobbyServer/LobbyServerProtocol.cs
+++ b/LobbyServer2/LobbyServer/LobbyServerProtocol.cs
@@ -882,6 +882,7 @@ namespace CentralServer.LobbyServer
                         };
                         client.Send(useGGPackNotification);
                     }
+                    CurrentServer.OnPlayerUsedGGPack(AccountId);
                 }
             }
         }


### PR DESCRIPTION
Add accolades back to the game.
Add personal stats screen back to the game.
Fix if game was shutdown with all players leaving do not send results to discord.
Add 5seconds delay before showing the stats fo use of gg boosts (but we all know gg boost do nothing :P but it should wait for it so later it can be used with xp stuff if we add it) 
Allow players to look at those stats for 60 seconds before sending ShutdownGameRequest to restart the game server and disconnect the player from it to go back to main screen