### PR TITLE
Add WillFill Back to the game!

### DIFF
--- a/EvoS.DirectoryServer/DirectoryServer.cs
+++ b/EvoS.DirectoryServer/DirectoryServer.cs
@@ -2,7 +2,6 @@ using System;
 using System.IO;
 using System.Net;
 using System.Threading;
-using CentralServer.LobbyServer;
 using CentralServer.LobbyServer.Session;
 using EvoS.DirectoryServer.Account;
 using EvoS.DirectoryServer.Inventory;
@@ -19,7 +18,6 @@ using Microsoft.AspNetCore.Hosting;
 using Microsoft.AspNetCore.Hosting.Server.Features;
 using Microsoft.AspNetCore.Http;
 using Newtonsoft.Json;
-using static EvoS.Framework.DataAccess.Daos.LoginDao;
 
 namespace EvoS.DirectoryServer
 {
@@ -208,6 +206,13 @@ namespace EvoS.DirectoryServer
 #if DEBUG
             account.AccountComponent.AppliedEntitlements.TryAdd("DEVELOPER_ACCESS", 1);
 #endif
+
+            // Check if WillFill is missing in CharacterData, if it is add it
+            account.CharacterData.TryGetValue(CharacterType.PendingWillFill, out PersistedCharacterData checkForMissingWillFill);
+            if (checkForMissingWillFill == null)
+            {
+                account.CharacterData.TryAdd(CharacterType.PendingWillFill, new PersistedCharacterData(CharacterType.PendingWillFill));
+            }
 
             foreach (PersistedCharacterData persistedCharacterData in account.CharacterData.Values)
             {

--- a/EvoS.Framework/Network/NetworkMessages/FreelancerUnavailableNotification.cs
+++ b/EvoS.Framework/Network/NetworkMessages/FreelancerUnavailableNotification.cs
@@ -1,0 +1,18 @@
+﻿using System;
+using EvoS.Framework.Network.WebSocket;
+
+namespace EvoS.Framework.Network.NetworkMessages
+{
+	[Serializable]
+	[EvosMessage(182)]
+	public class FreelancerUnavailableNotification : WebSocketMessage
+	{
+		public CharacterType oldCharacterType;
+
+		public CharacterType newCharacterType;
+
+		public string thiefName;
+
+		public bool ItsTooLateToChange;
+	}
+}

--- a/EvoS.Framework/Server/Characters/CharacterConfigs.cs
+++ b/EvoS.Framework/Server/Characters/CharacterConfigs.cs
@@ -462,6 +462,19 @@ namespace CentralServer.LobbyServer.Character
                     IsHidden = true
                 }
             },
+            {
+                CharacterType.PendingWillFill,
+                new CharacterConfig()
+                {
+                    AllowForBots = false,
+                    AllowForPlayers = true,
+                    CharacterRole = CharacterRole.None,
+                    CharacterType = CharacterType.PendingWillFill,
+                    Difficulty = 1,
+                    GameTypesProhibitedFrom = new List<GameType>(),
+                    IsHidden = false
+                }
+            }
         };
     }
 }

--- a/LobbyServer2/BridgeServer/BridgeServerProtocol.cs
+++ b/LobbyServer2/BridgeServer/BridgeServerProtocol.cs
@@ -4,6 +4,7 @@ using System.Linq;
 using System.Reflection;
 using System.Threading.Tasks;
 using CentralServer.LobbyServer;
+using CentralServer.LobbyServer.Character;
 using CentralServer.LobbyServer.Gamemode;
 using CentralServer.LobbyServer.Matchmaking;
 using CentralServer.LobbyServer.Session;
@@ -11,6 +12,7 @@ using Discord;
 using Discord.Webhook;
 using EvoS.Framework;
 using EvoS.Framework.Constants.Enums;
+using EvoS.Framework.DataAccess;
 using EvoS.Framework.Misc;
 using EvoS.Framework.Network.NetworkMessages;
 using EvoS.Framework.Network.Static;
@@ -29,7 +31,7 @@ namespace CentralServer.BridgeServer
         private LobbySessionInfo SessionInfo;
         public LobbyGameInfo GameInfo { private set; get; }
         public LobbyServerTeamInfo TeamInfo = new LobbyServerTeamInfo() { TeamPlayerInfo = new List<LobbyServerPlayerInfo>() };
-        
+
         public string URI => "ws://" + Address + ":" + Port;
         public GameStatus ServerGameStatus { get; private set; } = GameStatus.Stopped;
         public string ProcessCode { get; } = "Artemis" + DateTime.Now.Ticks;
@@ -129,7 +131,7 @@ namespace CentralServer.BridgeServer
                 Send(new RegisterGameServerResponse
                 {
                     Success = true
-                }, 
+                },
                 callbackId);
             }
             else if (type == typeof(ServerGameSummaryNotification))
@@ -625,10 +627,8 @@ namespace CentralServer.BridgeServer
                 AccountId = accountId,
                 NewSessionId = sessionInfo.ReconnectSessionToken
             };
-            
-            Send(reconnectPlayerRequest);
 
-            
+            Send(reconnectPlayerRequest);
 
             JoinGameServerRequest request = new JoinGameServerRequest
             {
@@ -733,7 +733,7 @@ namespace CentralServer.BridgeServer
             {
                 AcceptedPlayers = playerCount,
                 AcceptTimeout = new TimeSpan(0, 0, 0),
-                //SelectTimeout = TimeSpan.FromSeconds(30),
+                SelectTimeout = TimeSpan.FromSeconds(30),
                 LoadoutSelectTimeout = TimeSpan.FromSeconds(30),
                 ActiveHumanPlayers = playerCount,
                 ActivePlayers = playerCount,
@@ -778,10 +778,10 @@ namespace CentralServer.BridgeServer
             }
         }
 
-        public void SendGameInfo(LobbyServerProtocol playerConnection, GameStatus gamestatus = GameStatus.None) 
+        public void SendGameInfo(LobbyServerProtocol playerConnection, GameStatus gamestatus = GameStatus.None)
         {
 
-            if (gamestatus != GameStatus.None) 
+            if (gamestatus != GameStatus.None)
             {
                 GameInfo.GameStatus = gamestatus;
             }
@@ -821,6 +821,163 @@ namespace CentralServer.BridgeServer
             {
                 TeamInfo.TeamPlayerInfo[i].CharacterInfo = LobbyPlayerInfo.FromServer(TeamInfo.TeamPlayerInfo[i], 0, queueConfig).CharacterInfo;
             }
+        }
+
+        public bool CheckDuplicatedAndFill()
+        {
+            var teamACharacters = GetCharactersByTeam(Team.TeamA);
+            var teamBCharacters = GetCharactersByTeam(Team.TeamB);
+
+            var duplicateCharsA = GetDuplicateCharacters(teamACharacters);
+            var duplicateCharsB = GetDuplicateCharacters(teamBCharacters);
+
+            bool didWeHadFillOrDuplicate = false;
+            
+            foreach (long player in GetPlayers())
+            {
+                LobbyServerPlayerInfo playerInfo = GetPlayerInfo(player);
+                LobbyServerProtocol playerConnection = SessionManager.GetClientConnection(player);
+                if (playerConnection != null)
+                { 
+                    if (IsCharacterUnavailable(playerInfo, duplicateCharsA, duplicateCharsB))
+                    {
+                        var thiefName = GetThiefName(playerInfo, duplicateCharsA, duplicateCharsB);
+
+                        playerConnection.Send(new FreelancerUnavailableNotification()
+                        {
+                            oldCharacterType = playerInfo.CharacterType,
+                            thiefName = thiefName,
+                            ItsTooLateToChange = false
+                        });
+
+                        playerInfo.ReadyState = ReadyState.Unknown;
+
+                        didWeHadFillOrDuplicate = true;
+                    }
+
+                    playerConnection.Send(new EnterFreelancerResolutionPhaseNotification()
+                    {
+                        SubPhase = FreelancerResolutionPhaseSubType.DUPLICATE_FREELANCER
+                    });
+
+                    SendGameInfo(playerConnection);
+                }
+            }
+
+            return didWeHadFillOrDuplicate;
+        }
+
+        private ILookup<CharacterType, LobbyServerPlayerInfo> GetCharactersByTeam(Team team)
+        {
+            return TeamInfo.TeamPlayerInfo
+                .Where(p => p.TeamId == team)
+                .ToLookup(p => p.CharacterInfo.CharacterType);
+        }
+
+        private IEnumerable<LobbyServerPlayerInfo> GetDuplicateCharacters(ILookup<CharacterType, LobbyServerPlayerInfo> characters)
+        {
+            return characters.Where(c => c.Count() > 1).SelectMany(c => c);
+        }
+
+        private bool IsCharacterUnavailable(LobbyServerPlayerInfo playerInfo, IEnumerable<LobbyServerPlayerInfo> duplicateCharsA, IEnumerable<LobbyServerPlayerInfo> duplicateCharsB)
+        {
+            return playerInfo.CharacterType == CharacterType.PendingWillFill ||
+                   (playerInfo.TeamId == Team.TeamA && duplicateCharsA.Contains(playerInfo) && duplicateCharsA.First() != playerInfo) ||
+                   (playerInfo.TeamId == Team.TeamB && duplicateCharsB.Contains(playerInfo) && duplicateCharsB.First() != playerInfo);
+        }
+
+        private string GetThiefName(LobbyServerPlayerInfo playerInfo, IEnumerable<LobbyServerPlayerInfo> duplicateCharsA, IEnumerable<LobbyServerPlayerInfo> duplicateCharsB)
+        {
+            if (playerInfo.CharacterType == CharacterType.PendingWillFill) return "";
+
+            var thiefChars = playerInfo.TeamId == Team.TeamA ? duplicateCharsA : duplicateCharsB;
+            return thiefChars.Where(p => p.CharacterType == playerInfo.CharacterType && p.AccountId != playerInfo.AccountId).Select(p => p.Handle).FirstOrDefault();
+        }
+
+        public void CheckIfAllSelected()
+        {
+            var teamACharacters = GetCharactersByTeam(Team.TeamA);
+            var teamBCharacters = GetCharactersByTeam(Team.TeamB);
+
+            var duplicateCharsA = GetDuplicateCharacters(teamACharacters);
+            var duplicateCharsB = GetDuplicateCharacters(teamBCharacters);
+            
+            foreach (long player in GetPlayers())
+            {
+                LobbyServerPlayerInfo playerInfo = GetPlayerInfo(player);
+                LobbyServerProtocol playerConnection = SessionManager.GetClientConnection(player);
+                PersistedAccountData account = DB.Get().AccountDao.GetAccount(playerInfo.AccountId);
+
+                if (playerConnection != null && IsCharacterUnavailable(playerInfo, duplicateCharsA, duplicateCharsB) && playerInfo.ReadyState != ReadyState.Ready)
+                {
+                    CharacterType randomType = account.AccountComponent.LastCharacter;
+                    if (account.AccountComponent.LastCharacter == playerInfo.CharacterType)
+                    {
+                        // If they do not press ready and do not select a new character force them a random character else use the one they selected
+                        randomType = AssignRandomCharacter(playerInfo, teamACharacters, teamBCharacters);
+                    }
+                    
+                    UpdateAccountCharacter(playerInfo, randomType);
+                    NotifyCharacterChange(playerConnection, playerInfo, randomType);
+                    SetPlayerReady(playerConnection, playerInfo, randomType);
+                }
+            }
+        }
+
+        private CharacterType AssignRandomCharacter(LobbyServerPlayerInfo playerInfo, ILookup<CharacterType, LobbyServerPlayerInfo> teamACharacters, ILookup<CharacterType, LobbyServerPlayerInfo> teamBCharacters)
+        {
+            Random rand = new Random();
+            List<CharacterType> availableTypes = CharacterConfigs.Characters
+                .Where(cc => cc.Value.AllowForPlayers && cc.Value.CharacterRole != CharacterRole.None)
+                .Select(cc => cc.Key)
+                .ToList();
+
+            CharacterType randomType = CharacterType.None;
+
+            while (true)
+            {
+                randomType = availableTypes[rand.Next(availableTypes.Count)];
+
+                if (playerInfo.TeamId == Team.TeamA && !teamACharacters[randomType].Any()) break;
+                if (playerInfo.TeamId == Team.TeamB && !teamBCharacters[randomType].Any()) break;
+            }
+
+            log.Info($"Selecting random character for {playerInfo.Handle} {randomType}");
+
+            return randomType;
+        }
+
+        private void UpdateAccountCharacter(LobbyServerPlayerInfo playerInfo, CharacterType randomType)
+        {
+            PersistedAccountData account = DB.Get().AccountDao.GetAccount(playerInfo.AccountId);
+            account.AccountComponent.LastCharacter = randomType;
+            DB.Get().AccountDao.UpdateAccount(account);
+        }
+
+        private void NotifyCharacterChange(LobbyServerProtocol playerConnection, LobbyServerPlayerInfo playerInfo, CharacterType randomType)
+        {
+            PersistedAccountData account = DB.Get().AccountDao.GetAccount(playerInfo.AccountId);
+
+            playerConnection.Send(new ForcedCharacterChangeFromServerNotification()
+            {
+                ChararacterInfo = LobbyCharacterInfo.Of(account.CharacterData[randomType]),
+            });
+
+            playerConnection.Send(new FreelancerUnavailableNotification()
+            {
+                oldCharacterType = playerInfo.CharacterType,
+                newCharacterType = randomType,
+                ItsTooLateToChange = true,
+            });
+        }
+
+        private void SetPlayerReady(LobbyServerProtocol playerConnection, LobbyServerPlayerInfo playerInfo, CharacterType randomType)
+        {
+            PersistedAccountData account = DB.Get().AccountDao.GetAccount(playerInfo.AccountId);
+
+            playerInfo.CharacterInfo = LobbyCharacterInfo.Of(account.CharacterData[randomType]);
+            playerInfo.ReadyState = ReadyState.Ready;
+            SendGameInfo(playerConnection);
         }
     }
 }

--- a/LobbyServer2/LobbyServer/GameMode/GameModeManager.cs
+++ b/LobbyServer2/LobbyServer/GameMode/GameModeManager.cs
@@ -106,7 +106,7 @@ namespace CentralServer.LobbyServer.Gamemode
         {
             GameTypeAvailability type = new GameTypeAvailability();
             type.IsActive = LobbyConfiguration.GetGameTypePvPAvailable();
-            type.MaxWillFillPerTeam = 0;
+            type.MaxWillFillPerTeam = 4;
             type.SubTypes = new List<GameSubType>()
             {
                 LoadGameSubType(ConfigFiles[GameType.PvP])

--- a/LobbyServer2/LobbyServer/LobbyServerProtocol.cs
+++ b/LobbyServer2/LobbyServer/LobbyServerProtocol.cs
@@ -429,6 +429,18 @@ namespace CentralServer.LobbyServer
                 OriginalPlayerInfoUpdate = update,
                 ResponseId = request.RequestId
             };
+
+            if (CurrentServer != null)
+            {
+                CurrentServer.SendGameInfoNotifications();
+                if (CurrentServer.GameInfo.GameStatus == GameStatus.FreelancerSelecting)
+                {
+                    Send(new ForcedCharacterChangeFromServerNotification()
+                    {
+                        ChararacterInfo = playerInfo.CharacterInfo,
+                    });
+                }
+            }
             Send(response);
             BroadcastRefreshGroup();
         }
@@ -537,6 +549,13 @@ namespace CentralServer.LobbyServer
             }
             else
             {
+                if (CurrentServer != null)
+                {
+                    if (contextualReadyState.ReadyState == ReadyState.Ready)
+                    {
+                        CurrentServer.GetPlayerInfo(AccountId).ReadyState = ReadyState.Ready;
+                    }
+                }
                 UpdateGroupReadyState();
                 BroadcastRefreshGroup();
             }


### PR DESCRIPTION
fix: check for duplicate characters if there is a duplicate character allow them to change (Could happen in solo que or the old trick ready up all at once)
fix: allow WillFill to be selected and ready up on match start they will be able to select a new character

If they do not pick a character they will be forced to a random character This happens in willfill and or duplicated character They could choose not to pick one and play russian roulette with this.