### PR TITLE
Trying to resolve an issue where TeamInfo was providing incorrect information by setting its access modifier to private.

### DIFF
--- a/LobbyServer2/BridgeServer/BridgeServerProtocol.cs
+++ b/LobbyServer2/BridgeServer/BridgeServerProtocol.cs
@@ -11,6 +11,7 @@ using Discord;
 using Discord.Webhook;
 using EvoS.Framework;
 using EvoS.Framework.Constants.Enums;
+using EvoS.Framework.DataAccess;
 using EvoS.Framework.Misc;
 using EvoS.Framework.Network.NetworkMessages;
 using EvoS.Framework.Network.Static;
@@ -28,8 +29,8 @@ namespace CentralServer.BridgeServer
         public int Port;
         private LobbySessionInfo SessionInfo;
         public LobbyGameInfo GameInfo { private set; get; }
-        public LobbyServerTeamInfo TeamInfo = new LobbyServerTeamInfo() { TeamPlayerInfo = new List<LobbyServerPlayerInfo>() };
-        
+        public LobbyServerTeamInfo TeamInfo { private set; get; } = new LobbyServerTeamInfo() { TeamPlayerInfo = new List<LobbyServerPlayerInfo>() };
+
         public string URI => "ws://" + Address + ":" + Port;
         public GameStatus ServerGameStatus { get; private set; } = GameStatus.Stopped;
         public string ProcessCode { get; } = "Artemis" + DateTime.Now.Ticks;
@@ -447,8 +448,8 @@ namespace CentralServer.BridgeServer
                                     try
                                     {
                                         PlayerGameSummary playerA = teamA[teams];
-                                        LobbyServerPlayerInfo playerInfoA = SessionManager.GetPlayerInfo(playerA.AccountId);
-                                        eb.AddField($"{playerInfoA.Handle} ({playerA.CharacterName})", $"**[ {playerA.NumAssists} : {playerA.NumDeaths} : {playerA.NumKills} ] [ {playerA.TotalPlayerDamage} : {playerA.GetTotalHealingFromAbility() + playerA.TotalPlayerAbsorb} : {playerA.TotalPlayerDamageReceived} ]**", true);
+                                        PersistedAccountData account = DB.Get().AccountDao.GetAccount(playerA.AccountId);
+                                        eb.AddField($"{account.Handle} ({playerA.CharacterName})", $"**[ {playerA.NumAssists} : {playerA.NumDeaths} : {playerA.NumKills} ] [ {playerA.TotalPlayerDamage} : {playerA.GetTotalHealingFromAbility() + playerA.TotalPlayerAbsorb} : {playerA.TotalPlayerDamageReceived} ]**", true);
                                     }
                                     catch
                                     {
@@ -460,8 +461,8 @@ namespace CentralServer.BridgeServer
                                     try
                                     {
                                         PlayerGameSummary playerB = teamB[teams];
-                                        LobbyServerPlayerInfo playerInfoB = SessionManager.GetPlayerInfo(playerB.AccountId);
-                                        eb.AddField($"{playerInfoB.Handle} ({playerB.CharacterName})", $"**[ {playerB.NumAssists} : {playerB.NumDeaths} : {playerB.NumKills} ] [ {playerB.TotalPlayerDamage} : {playerB.GetTotalHealingFromAbility() + playerB.TotalPlayerAbsorb} : {playerB.TotalPlayerDamageReceived} ]**", true);
+                                        PersistedAccountData account = DB.Get().AccountDao.GetAccount(playerB.AccountId);
+                                        eb.AddField($"{account.Handle} ({playerB.CharacterName})", $"**[ {playerB.NumAssists} : {playerB.NumDeaths} : {playerB.NumKills} ] [ {playerB.TotalPlayerDamage} : {playerB.GetTotalHealingFromAbility() + playerB.TotalPlayerAbsorb} : {playerB.TotalPlayerDamageReceived} ]**", true);
                                     }
                                     catch
                                     {
@@ -720,16 +721,16 @@ namespace CentralServer.BridgeServer
                 LobbyServerPlayerInfo playerInfo = SessionManager.GetPlayerInfo(client.AccountId);
                 playerInfo.ReadyState = ReadyState.Ready;
                 playerInfo.TeamId = team;
-                playerInfo.PlayerId = this.TeamInfo.TeamPlayerInfo.Count + 1;
+                playerInfo.PlayerId = TeamInfo.TeamPlayerInfo.Count + 1;
                 log.Info($"adding player {client.UserName}, {client.AccountId} to {team}. readystate: {playerInfo.ReadyState}");
-                this.TeamInfo.TeamPlayerInfo.Add(playerInfo);
+                TeamInfo.TeamPlayerInfo.Add(playerInfo);
             }
         }
 
         public void BuildGameInfo(GameType gameType, GameSubType gameMode)
         {
             int playerCount = GetClients().Count;
-            this.GameInfo = new LobbyGameInfo
+            GameInfo = new LobbyGameInfo
             {
                 AcceptedPlayers = playerCount,
                 AcceptTimeout = new TimeSpan(0, 0, 0),


### PR DESCRIPTION
Enhanced the game results feature in Discord: now, instead of relying on the online status of a player to retrieve their handle, we use the database to ensure accurate information is displayed even if the player logs off.