### PR TITLE
Fixed where people would randomly be in wrong teaminfo

### DIFF
--- a/LobbyServer2/BridgeServer/BridgeServerProtocol.cs
+++ b/LobbyServer2/BridgeServer/BridgeServerProtocol.cs
@@ -491,7 +491,7 @@ namespace CentralServer.BridgeServer
                 {
                     log.Error(ex);
                 }
-                ServerGameStatus = GameStatus.Stopped;
+                ServerGameStatus = GameStatus.None;
                 //Wait a bit so people can look at stuff but we do have to send it so server can restart
                 await Task.Delay(60000);
                 Send(new ShutdownGameRequest());


### PR DESCRIPTION
due to connecting within 1 min back to a game, and it would use the old server to connect to instead of using a new server
And such mess up with teaminfo because TeamInfo was set already on previous match.