### PR TITLE
Fix: End Screen Bug with Character Change

### DIFF
--- a/EvoS.Framework/Network/Static/LobbyPlayerInfo.cs
+++ b/EvoS.Framework/Network/Static/LobbyPlayerInfo.cs
@@ -16,8 +16,11 @@ namespace EvoS.Framework.Network.Static
 
         public bool ReplacedWithBots { get; set; }
 
-        public static LobbyPlayerInfo FromServer(LobbyServerPlayerInfo serverInfo, int maxPlayerLevel,
-            MatchmakingQueueConfig queueConfig)
+        public static LobbyPlayerInfo FromServer(
+            LobbyServerPlayerInfo serverInfo, 
+            int maxPlayerLevel,
+            MatchmakingQueueConfig queueConfig, 
+            bool keepOldData = false)
         {
             LobbyPlayerInfo lobbyPlayerInfo = null;
             if (serverInfo != null)
@@ -32,29 +35,30 @@ namespace EvoS.Framework.Network.Static
                     }
                 }
 
-                // Refetch data from DB was not updated otherwise
+                // If keepOldData is set to true we keep the old values
+                // Else we use new fresh data
                 PersistedAccountData account = DB.Get().AccountDao.GetAccount(serverInfo.AccountId);
 
                 lobbyPlayerInfo = new LobbyPlayerInfo
                 {
-                    AccountId = account.AccountId,
+                    AccountId = keepOldData ? serverInfo.AccountId : account.AccountId,
                     PlayerId = serverInfo.PlayerId,
                     CustomGameVisualSlot = serverInfo.CustomGameVisualSlot,
-                    Handle = account.Handle,
-                    TitleID = account.AccountComponent.SelectedTitleID,
+                    Handle = keepOldData ? serverInfo.Handle : account.Handle,
+                    TitleID = keepOldData ? serverInfo.TitleID : account.AccountComponent.SelectedTitleID,
                     TitleLevel = serverInfo.TitleLevel,
-                    BannerID = account.AccountComponent.SelectedBackgroundBannerID,
-                    EmblemID = account.AccountComponent.SelectedForegroundBannerID,
+                    BannerID = keepOldData ? serverInfo.BannerID : account.AccountComponent.SelectedBackgroundBannerID,
+                    EmblemID = keepOldData ? serverInfo.EmblemID : account.AccountComponent.SelectedForegroundBannerID,
                     RibbonID = serverInfo.RibbonID,
                     IsGameOwner = serverInfo.IsGameOwner,
                     ReplacedWithBots = serverInfo.ReplacedWithBots,
                     IsNPCBot = serverInfo.IsNPCBot,
                     IsLoadTestBot = serverInfo.IsLoadTestBot,
-                    BotsMasqueradeAsHumans = (queueConfig != null && queueConfig.BotsMasqueradeAsHumans),
+                    BotsMasqueradeAsHumans = queueConfig != null && queueConfig.BotsMasqueradeAsHumans,
                     Difficulty = serverInfo.Difficulty,
                     BotCanTaunt = serverInfo.BotCanTaunt,
                     TeamId = serverInfo.TeamId,
-                    CharacterInfo = ((serverInfo.CharacterInfo == null) ? null : LobbyCharacterInfo.Of(account.CharacterData[account.AccountComponent.LastCharacter])),
+                    CharacterInfo = (serverInfo.CharacterInfo == null) ? null : (keepOldData ? serverInfo.CharacterInfo : LobbyCharacterInfo.Of(account.CharacterData[account.AccountComponent.LastCharacter])),
                     RemoteCharacterInfos = list,
                     ReadyState = serverInfo.ReadyState,
                     ControllingPlayerId =

--- a/EvoS.Framework/Network/Static/LobbyTeamInfo.cs
+++ b/EvoS.Framework/Network/Static/LobbyTeamInfo.cs
@@ -35,8 +35,11 @@ namespace EvoS.Framework.Network.Static
                 select p;
         }
 
-        public static LobbyTeamInfo FromServer(LobbyServerTeamInfo serverInfo, int maxPlayerLevel,
-            MatchmakingQueueConfig queueConfig)
+        public static LobbyTeamInfo FromServer(
+            LobbyServerTeamInfo serverInfo, 
+            int maxPlayerLevel,
+            MatchmakingQueueConfig queueConfig, 
+            bool keepOldData = false)
         {
             LobbyTeamInfo lobbyTeamInfo = null;
             if (serverInfo != null)
@@ -47,8 +50,12 @@ namespace EvoS.Framework.Network.Static
                     lobbyTeamInfo.TeamPlayerInfo = new List<LobbyPlayerInfo>();
                     foreach (LobbyServerPlayerInfo serverInfo2 in serverInfo.TeamPlayerInfo)
                     {
-                        lobbyTeamInfo.TeamPlayerInfo.Add(LobbyPlayerInfo.FromServer(serverInfo2, maxPlayerLevel,
-                            queueConfig));
+                        lobbyTeamInfo.TeamPlayerInfo.Add(
+                            LobbyPlayerInfo.FromServer(
+                                serverInfo2, 
+                                maxPlayerLevel,
+                                queueConfig,
+                                keepOldData));
                     }
                 }
             }

--- a/LobbyServer2/BridgeServer/BridgeServerProtocol.cs
+++ b/LobbyServer2/BridgeServer/BridgeServerProtocol.cs
@@ -604,7 +604,10 @@ namespace CentralServer.BridgeServer
             GameInfo.ggPackUsedAccountIDs.TryGetValue(accountId, out ggPackUsedAccountIDs);
             GameInfo.ggPackUsedAccountIDs[accountId] = ggPackUsedAccountIDs + 1;
 
-            SendGameInfoNotifications();
+            // *EDGE CASE* Set to true to keep all current game characters
+            // Incase someone leaves a match and changes there character,banners etc..,
+            // make sure we have the old character data and not the new character data for this state
+            SendGameInfoNotifications(true);
         }
 
         public bool IsAvailable()
@@ -768,19 +771,19 @@ namespace CentralServer.BridgeServer
             GameInfo.GameStatus = status;
         }
 
-        public void SendGameInfoNotifications()
+        public void SendGameInfoNotifications(bool keepOldData = false)
         {
             foreach (long player in GetPlayers())
             {
                 LobbyServerProtocol playerConnection = SessionManager.GetClientConnection(player);
                 if (playerConnection != null)
                 {
-                    SendGameInfo(playerConnection);
+                    SendGameInfo(playerConnection, GameStatus.None, keepOldData);
                 }
             }
         }
 
-        public void SendGameInfo(LobbyServerProtocol playerConnection, GameStatus gamestatus = GameStatus.None)
+        public void SendGameInfo(LobbyServerProtocol playerConnection, GameStatus gamestatus = GameStatus.None, bool keepOldData = false)
         {
 
             if (gamestatus != GameStatus.None)
@@ -792,7 +795,7 @@ namespace CentralServer.BridgeServer
             GameInfoNotification notification = new GameInfoNotification()
             {
                 GameInfo = GameInfo,
-                TeamInfo = LobbyTeamInfo.FromServer(TeamInfo, 0, new MatchmakingQueueConfig()),
+                TeamInfo = LobbyTeamInfo.FromServer(TeamInfo, 0, new MatchmakingQueueConfig(), keepOldData),
                 PlayerInfo = LobbyPlayerInfo.FromServer(playerInfo, 0, new MatchmakingQueueConfig())
             };
 


### PR DESCRIPTION
Addressing a bug where players could exit a match prior to the end screen and alter their character, resulting in unintended consequences for the remaining players' end screen experience. Normally, fetching new data is possible, but in this instance, it is not. This issue specifically arises when a player utilizes a GG Boost during a match while another player has left and subsequently changed their character, banner, title, or other related elements.