### PR TITLE
Resolve character selection bug when fill

### DIFF
--- a/LobbyServer2/BridgeServer/BridgeServerProtocol.cs
+++ b/LobbyServer2/BridgeServer/BridgeServerProtocol.cs
@@ -1028,10 +1028,11 @@ namespace CentralServer.BridgeServer
                 UpdateAccountCharacter(GetPlayerInfo(playerConnection.AccountId), playerConnection.OldCharacter);
                 if (!isDisconnected)
                 {
-                    LobbyServerPlayerInfo playerInfo = SessionManager.UpdateLobbyServerPlayerInfo(playerConnection.AccountId);
-                    playerConnection.Send(new ForcedCharacterChangeFromServerNotification()
+                    SessionManager.UpdateLobbyServerPlayerInfo(playerConnection.AccountId);
+                    PersistedAccountData account = DB.Get().AccountDao.GetAccount(playerConnection.AccountId);
+                    playerConnection.Send(new PlayerAccountDataUpdateNotification()
                     {
-                        ChararacterInfo = playerInfo.CharacterInfo,
+                        AccountData = account,
                     });
                 }
             }


### PR DESCRIPTION
Fix the case where people where fill but where not able to select there new character due to character desync 
this is a fix for bug in 3b90fad3cdc71cd5ba13fc6863b4f4a6b9dfb06a