### PR TITLE
Convert Discord to a true bot!

### DIFF
--- a/LobbyServer2/CentralServer.csproj
+++ b/LobbyServer2/CentralServer.csproj
@@ -5,7 +5,9 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Discord.Net.Webhook" Version="3.9.0" />
+    <PackageReference Include="Discord.Net.Commands" Version="3.10.0" />
+    <PackageReference Include="Discord.Net.Core" Version="3.10.0" />
+    <PackageReference Include="Discord.Net.WebSocket" Version="3.10.0" />
     <PackageReference Include="System.ServiceModel.Primitives" Version="4.9.0" />
   </ItemGroup>
 

--- a/LobbyServer2/Config/lobby.yaml
+++ b/LobbyServer2/Config/lobby.yaml
@@ -2,20 +2,15 @@
 MOTDText: "Join the project Discord: https://discord.gg/yrZRHJaAUg"
 PatchNotesCommitsUrl: https://api.github.com/repos/Zheneq/EvoS/commits?per_page=10
 Discord:
-  Enabled: false
-  AdminChannel: # Discord Webhook for admin reports
-    Webhook: ""
-    ThreadId: # leave empty to post into the channel
+  Enabled: true
+  BotToken: "" # Enter the bots token
+  AdminChannel: 0 # Discord channel id for admin reports
   AdminEnableUserReports: true
-  AdminUserReportThreadId:
+  AdminUserReportChannelId: 0 # Discord channel id from ingame user/bug reports
   AdminEnableChatAudit: true
-  AdminChatAuditThreadId:
-  GameLogChannel:
-    Webhook: "" # Discord Webhook for game results
-    ThreadId: 
-  LobbyChannel:
-    Webhook: "" # Discord Webhook for lobby status and chat
-    ThreadId:
+  AdminChatAuditChannelId: 0
+  GameLogChannel: 0 # Discord channel Id for game results
+  LobbyChannel: 0 # Discord channel Id for lobby status and chat
   LobbyEnableChat: true
   LobbyEnableServerStatus: true
   LobbyChannelUpdatePeriodSeconds: 300

--- a/LobbyServer2/LobbyServer/Discord/DiscordClientWrapper.cs
+++ b/LobbyServer2/LobbyServer/Discord/DiscordClientWrapper.cs
@@ -1,8 +1,14 @@
 using System.Collections.Generic;
+using System.Linq;
 using System.Threading.Tasks;
+using CentralServer.LobbyServer.Session;
 using Discord;
-using Discord.Webhook;
+using Discord.Net;
+using Discord.WebSocket;
+using EvoS.Framework.Constants.Enums;
+using EvoS.Framework.Network.NetworkMessages;
 using log4net;
+using Newtonsoft.Json;
 
 namespace CentralServer.LobbyServer.Discord
 {
@@ -10,37 +16,137 @@ namespace CentralServer.LobbyServer.Discord
     {
         private static readonly ILog log = LogManager.GetLogger(typeof(DiscordClientWrapper));
         
-        private readonly DiscordWebhookClient client;
-        private readonly ulong? threadId;
-        
-        public DiscordClientWrapper(DiscordChannel conf)
+        private readonly DiscordSocketClient client;
+        private readonly ulong? channelId;
+        private static bool isReady = false;
+        private static readonly DiscordSocketConfig discordConfig = new DiscordSocketConfig
         {
-            client = new DiscordWebhookClient(conf.Webhook);
+            GatewayIntents = GatewayIntents.AllUnprivileged | GatewayIntents.MessageContent
+        };
+
+        public DiscordClientWrapper(DiscordConfiguration conf)
+        {
+
+            client = new DiscordSocketClient(discordConfig);
+            channelId = conf.LobbyChannel;
+            client.LoginAsync(TokenType.Bot, conf.BotToken);
+            client.StartAsync();
+            client.SetGameAsync("Atlas Reactor");
             client.Log += Log;
-            threadId = conf.ThreadId;
+            client.Ready += Ready;
+            client.SlashCommandExecuted += SlashCommandHandler;
+            client.MessageReceived += ClientOnMessageReceived;
+        }
+
+        public async Task Ready()
+        {
+            SlashCommandBuilder infoCommand = new SlashCommandBuilder();
+            infoCommand.WithName("info");
+            infoCommand.WithDescription("Retrieve info from Atlas Reactor");
+
+            SlashCommandBuilder broadcastCommand = new SlashCommandBuilder();
+            broadcastCommand.WithName("broadcast");
+            broadcastCommand.WithDescription("Send a broadcast to atlas reactor lobby");
+            broadcastCommand.AddOption("message", ApplicationCommandOptionType.String, "Message to send", true);
+            broadcastCommand.WithDefaultMemberPermissions(GuildPermission.ManageGuild);
+
+            try
+            {
+                await client.CreateGlobalApplicationCommandAsync(infoCommand.Build());
+                await client.CreateGlobalApplicationCommandAsync(broadcastCommand.Build());
+            }
+            catch (HttpException exception)
+            {
+                var json = JsonConvert.SerializeObject(exception.Errors, Formatting.Indented);
+                log.Info(json);
+            }
+            isReady = true;
+        }
+
+        private async Task ClientOnMessageReceived(SocketMessage socketMessage)
+        {
+            await Task.Run(() =>
+            {
+                // Check if Author is not a bot and allow only reading from the discord LobbyChannel
+                if (!socketMessage.Author.IsBot && socketMessage.Channel.Id == channelId)
+                {
+                    ChatNotification message = new ChatNotification
+                    {
+                        SenderHandle = $"(Discord) {socketMessage.Author.Username}",
+                        ConsoleMessageType = ConsoleMessageType.GlobalChat,
+                        Text = socketMessage.Content,
+                    };
+                    foreach (long playerAccountId in SessionManager.GetOnlinePlayers())
+                    {
+                        LobbyServerProtocol player = SessionManager.GetClientConnection(playerAccountId);
+                        if (player != null && player.CurrentServer == null)
+                        {
+                            player.Send(message);
+                        }
+                    }
+                }
+            });
+        }
+
+        private async Task SlashCommandHandler(SocketSlashCommand command)
+        {
+            if (command.Data.Name == "info")
+            {
+                DiscordLobbyUtils.Status status = DiscordLobbyUtils.GetStatus();
+                await command.RespondAsync(embed:
+                                new EmbedBuilder
+                                {
+                                    Title = DiscordLobbyUtils.BuildPlayerCountSummary(status),
+                                    Color = Color.Green
+                                }.Build(), ephemeral: true);
+            }
+            if (command.Data.Name == "broadcast")
+            {
+                ChatNotification message = new ChatNotification
+                {
+                    SenderHandle = command.User.Username,
+                    ConsoleMessageType = ConsoleMessageType.BroadcastMessage,
+                    Text = command.Data.Options.First().Value.ToString(),
+                };
+                foreach (long playerAccountId in SessionManager.GetOnlinePlayers())
+                {
+                    LobbyServerProtocol player = SessionManager.GetClientConnection(playerAccountId);
+                    if (player != null)
+                    {
+                        player.Send(message);
+                    }
+                }
+                await command.RespondAsync("Broadcast send", ephemeral: true);
+            }
         }
 
         private static Task Log(LogMessage msg)
         {
             return DiscordUtils.Log(log, msg);
         }
-        
-        public Task<ulong> SendMessageAsync(
+
+        public bool IsReady()
+        {
+            return isReady;
+        }
+
+        public Task<IUserMessage> SendMessageAsync(
             string text = null,
             bool isTTS = false,
-            IEnumerable<Embed> embeds = null,
-            string username = null,
-            string avatarUrl = null,
+            Embed embed = null,
             RequestOptions options = null,
             AllowedMentions allowedMentions = null,
+            MessageReference messageReference = null,
             MessageComponent components = null,
+            ISticker[] stickers = null,
+            Embed[] embeds = null,
             MessageFlags flags = MessageFlags.None,
-            ulong? threadIdOverride = null)
+            ulong? channelIdOverride = null)
         {
-            ulong? _threadId = threadIdOverride ?? threadId;
-            if (_threadId == 0) _threadId = null;
-            return client.SendMessageAsync(
-                text, isTTS, embeds, username, avatarUrl, options, allowedMentions, components, flags, _threadId);
+            ulong? _channelId = channelIdOverride ?? channelId;
+            if (_channelId.Value == 0) return null;
+            IMessageChannel chnl = client.GetChannel(_channelId.Value) as IMessageChannel;
+            return chnl.SendMessageAsync(text, isTTS, embed, options, allowedMentions, messageReference, components, stickers, embeds, flags);
         }
     }
 }

--- a/LobbyServer2/LobbyServer/Discord/DiscordConfiguration.cs
+++ b/LobbyServer2/LobbyServer/Discord/DiscordConfiguration.cs
@@ -1,39 +1,23 @@
-﻿using WebSocketSharp;
-
-namespace CentralServer.LobbyServer.Discord
+﻿namespace CentralServer.LobbyServer.Discord
 {
     public class DiscordConfiguration
     {
         public bool Enabled = false;
-        
-        public DiscordChannel AdminChannel;
-        public DiscordChannel GameLogChannel;
-        public DiscordChannel LobbyChannel;
+
+        public string BotToken = "";
+
+        public ulong? AdminChannel;
+        public ulong? GameLogChannel;
+        public ulong? LobbyChannel;
 
         public bool AdminEnableUserReports;
-        public ulong? AdminUserReportThreadId;
+        public ulong? AdminUserReportChannelId;
         public bool AdminEnableChatAudit;
-        public ulong? AdminChatAuditThreadId;
+        public ulong? AdminChatAuditChannelId;
         
         public bool LobbyEnableChat;
         public bool LobbyEnableServerStatus;
         public int LobbyChannelUpdatePeriodSeconds = 300;
         public bool LobbyChannelUpdateOnChangeOnly = true;
-    }
-
-    public class DiscordChannel
-    {
-        public string Webhook = "";
-        public ulong? ThreadId = null;
-    }
-
-    public static class DiscordConfigExtensions
-    {
-        public static bool IsChannel(this DiscordChannel channel)
-        {
-            return channel != null
-                   && channel.Webhook != null
-                   && channel.Webhook.MaybeUri();
-        }
     }
 }


### PR DESCRIPTION
no longer uses Webhooks
 - Allows 2 way comunication chat from discord <=> lobby
 - Gives 2 discord commands /info and /broadcast
 - /info returns the curent players online - que - ingame
 - /broadcast allows to send a broadcast to lobby to all players (Needs  ManageGuild permission to be able to use) handy to notify users Aka server restart etc..

we no longer need ThreadId all works with just ChannelId's

Create a bot at : https://discord.com/developers/applications Then invite the bot to the server
`https://discord.com/oauth2/authorize?client_id=<APPLICATION ID>&permissions=0&scope=bot%20applications.commands`
Replace APPLICATION ID with id found in developers secion of the bot 
make sure to give the bot the permission MESSAGE CONTENT INTENT in the section "Bot" to be able to read messages