### PR TITLE
Enchange Discord

### DIFF
--- a/LobbyServer2/CentralServer.csproj
+++ b/LobbyServer2/CentralServer.csproj
@@ -5,7 +5,10 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Discord.Net.Webhook" Version="3.9.0" />
+    <PackageReference Include="Discord.Net.Commands" Version="3.10.0" />
+    <PackageReference Include="Discord.Net.Core" Version="3.10.0" />
+    <PackageReference Include="Discord.Net.Webhook" Version="3.10.0" />
+    <PackageReference Include="Discord.Net.WebSocket" Version="3.10.0" />
     <PackageReference Include="System.ServiceModel.Primitives" Version="4.9.0" />
   </ItemGroup>
 

--- a/LobbyServer2/Config/lobby.yaml
+++ b/LobbyServer2/Config/lobby.yaml
@@ -3,6 +3,9 @@ MOTDText: "Join the project Discord: https://discord.gg/yrZRHJaAUg"
 PatchNotesCommitsUrl: https://api.github.com/repos/Zheneq/EvoS/commits?per_page=10
 Discord:
   Enabled: false
+  UseDiscordBot: true # Enable if you want the bot in your discord channel to enchancement to the webhooks adds commands and  chat from discord to ar
+  BotToken: "" # Enter the bots token leave empty to disable
+  BotChannelId: 0 # Enter the channel id for 2way chat (usualy the LobbyChannel id)
   AdminChannel: # Discord Webhook for admin reports
     Webhook: ""
     ThreadId: # leave empty to post into the channel

--- a/LobbyServer2/LobbyServer/Discord/DiscordBotWrapper.cs
+++ b/LobbyServer2/LobbyServer/Discord/DiscordBotWrapper.cs
@@ -1,0 +1,143 @@
+using System.Linq;
+using System.Threading.Tasks;
+using CentralServer.LobbyServer.Session;
+using Discord;
+using Discord.Net;
+using Discord.WebSocket;
+using EvoS.Framework.Constants.Enums;
+using EvoS.Framework.Network.NetworkMessages;
+using log4net;
+using Newtonsoft.Json;
+
+namespace CentralServer.LobbyServer.Discord
+{
+    public class DiscordBotWrapper
+    {
+        private static readonly ILog log = LogManager.GetLogger(typeof(DiscordBotWrapper));
+        
+        private readonly DiscordSocketClient botClient;
+        private static readonly DiscordSocketConfig discordConfig = new DiscordSocketConfig
+        {
+            GatewayIntents = GatewayIntents.AllUnprivileged | GatewayIntents.MessageContent
+        };
+        private readonly ulong? botChannelId;
+        
+        public DiscordBotWrapper(DiscordConfiguration conf)
+        {
+            botClient = new DiscordSocketClient(discordConfig);
+            botChannelId = conf.BotChannelId;
+            botClient.LoginAsync(TokenType.Bot, conf.BotToken);
+            botClient.StartAsync();
+            botClient.SetGameAsync("Atlas Reactor");
+            botClient.Log += Log;
+            botClient.Ready += Ready;
+            botClient.SlashCommandExecuted += SlashCommandHandler;
+            botClient.MessageReceived += ClientOnMessageReceived;
+        }
+
+        public async Task Ready()
+        {
+            SlashCommandBuilder infoCommand = new SlashCommandBuilder();
+            infoCommand.WithName("info");
+            infoCommand.WithDescription("Retrieve info from Atlas Reactor");
+
+            SlashCommandBuilder broadcastCommand = new SlashCommandBuilder();
+            broadcastCommand.WithName("broadcast");
+            broadcastCommand.WithDescription("Send a broadcast to atlas reactor lobby");
+            broadcastCommand.AddOption("message", ApplicationCommandOptionType.String, "Message to send", true);
+            broadcastCommand.WithDefaultMemberPermissions(GuildPermission.ManageGuild);
+
+            try
+            {
+                await botClient.CreateGlobalApplicationCommandAsync(infoCommand.Build());
+                await botClient.CreateGlobalApplicationCommandAsync(broadcastCommand.Build());
+            }
+            catch (HttpException exception)
+            {
+                var json = JsonConvert.SerializeObject(exception.Errors, Formatting.Indented);
+                log.Info(json);
+            }
+        }
+
+        private async Task ClientOnMessageReceived(SocketMessage socketMessage)
+        {
+            await Task.Run(() =>
+            {
+                // Check if Author is not a bot and allow only reading from the discord LobbyChannel
+                if (!socketMessage.Author.IsBot && socketMessage.Channel.Id == botChannelId && !socketMessage.Author.IsWebhook)
+                {
+                    ChatNotification message = new ChatNotification
+                    {
+                        SenderHandle = $"(Discord) {socketMessage.Author.Username}",
+                        ConsoleMessageType = ConsoleMessageType.GlobalChat,
+                        Text = socketMessage.Content,
+                    };
+                    foreach (long playerAccountId in SessionManager.GetOnlinePlayers())
+                    {
+                        LobbyServerProtocol player = SessionManager.GetClientConnection(playerAccountId);
+                        if (player != null && player.CurrentServer == null)
+                        {
+                            player.Send(message);
+                        }
+                    }
+                }
+            });
+        }
+
+        private async Task SlashCommandHandler(SocketSlashCommand command)
+        {
+            if (command.Data.Name == "info")
+            {
+                DiscordLobbyUtils.Status status = DiscordLobbyUtils.GetStatus();
+                await command.RespondAsync(embed:
+                                new EmbedBuilder
+                                {
+                                    Title = DiscordLobbyUtils.BuildPlayerCountSummary(status),
+                                    Color = Color.Green
+                                }.Build(), ephemeral: true);
+            }
+            if (command.Data.Name == "broadcast")
+            {
+                ChatNotification message = new ChatNotification
+                {
+                    SenderHandle = command.User.Username,
+                    ConsoleMessageType = ConsoleMessageType.BroadcastMessage,
+                    Text = command.Data.Options.First().Value.ToString(),
+                };
+                foreach (long playerAccountId in SessionManager.GetOnlinePlayers())
+                {
+                    LobbyServerProtocol player = SessionManager.GetClientConnection(playerAccountId);
+                    if (player != null)
+                    {
+                        player.Send(message);
+                    }
+                }
+                await command.RespondAsync("Broadcast send", ephemeral: true);
+            }
+        }
+
+        private static Task Log(LogMessage msg)
+        {
+            return DiscordUtils.Log(log, msg);
+        }
+
+        public Task<IUserMessage> SendMessageAsync(
+            string text = null,
+            bool isTTS = false,
+            Embed embed = null,
+            RequestOptions options = null,
+            AllowedMentions allowedMentions = null,
+            MessageReference messageReference = null,
+            MessageComponent components = null,
+            ISticker[] stickers = null,
+            Embed[] embeds = null,
+            MessageFlags flags = MessageFlags.None,
+            ulong? channelIdOverride = null)
+        {
+            ulong? _channelId = channelIdOverride ?? botChannelId;
+            if (_channelId.Value == 0) return null;
+            IMessageChannel chnl = botClient.GetChannel(_channelId.Value) as IMessageChannel;
+            return chnl.SendMessageAsync(text, isTTS, embed, options, allowedMentions, messageReference, components, stickers, embeds, flags);
+        }
+    }
+}

--- a/LobbyServer2/LobbyServer/Discord/DiscordClientWrapper.cs
+++ b/LobbyServer2/LobbyServer/Discord/DiscordClientWrapper.cs
@@ -1,15 +1,8 @@
 using System.Collections.Generic;
-using System.Linq;
 using System.Threading.Tasks;
-using CentralServer.LobbyServer.Session;
 using Discord;
-using Discord.Net;
 using Discord.Webhook;
-using Discord.WebSocket;
-using EvoS.Framework.Constants.Enums;
-using EvoS.Framework.Network.NetworkMessages;
 using log4net;
-using Newtonsoft.Json;
 
 namespace CentralServer.LobbyServer.Discord
 {
@@ -18,12 +11,6 @@ namespace CentralServer.LobbyServer.Discord
         private static readonly ILog log = LogManager.GetLogger(typeof(DiscordClientWrapper));
         
         private readonly DiscordWebhookClient client;
-        private readonly DiscordSocketClient botClient;
-        private static readonly DiscordSocketConfig discordConfig = new DiscordSocketConfig
-        {
-            GatewayIntents = GatewayIntents.AllUnprivileged | GatewayIntents.MessageContent
-        };
-        private readonly ulong? botChannelId;
         private readonly ulong? threadId;
         
         public DiscordClientWrapper(DiscordChannel conf)
@@ -31,100 +18,6 @@ namespace CentralServer.LobbyServer.Discord
             client = new DiscordWebhookClient(conf.Webhook);
             client.Log += Log;
             threadId = conf.ThreadId;
-        }
-
-        public DiscordClientWrapper(DiscordConfiguration conf)
-        {
-            botClient = new DiscordSocketClient(discordConfig);
-            botChannelId = conf.BotChannelId;
-            botClient.LoginAsync(TokenType.Bot, conf.BotToken);
-            botClient.StartAsync();
-            botClient.SetGameAsync("Atlas Reactor");
-            botClient.Log += Log;
-            botClient.Ready += Ready;
-            botClient.SlashCommandExecuted += SlashCommandHandler;
-            botClient.MessageReceived += ClientOnMessageReceived;
-        }
-
-        public async Task Ready()
-        {
-            SlashCommandBuilder infoCommand = new SlashCommandBuilder();
-            infoCommand.WithName("info");
-            infoCommand.WithDescription("Retrieve info from Atlas Reactor");
-
-            SlashCommandBuilder broadcastCommand = new SlashCommandBuilder();
-            broadcastCommand.WithName("broadcast");
-            broadcastCommand.WithDescription("Send a broadcast to atlas reactor lobby");
-            broadcastCommand.AddOption("message", ApplicationCommandOptionType.String, "Message to send", true);
-            broadcastCommand.WithDefaultMemberPermissions(GuildPermission.ManageGuild);
-
-            try
-            {
-                await botClient.CreateGlobalApplicationCommandAsync(infoCommand.Build());
-                await botClient.CreateGlobalApplicationCommandAsync(broadcastCommand.Build());
-            }
-            catch (HttpException exception)
-            {
-                var json = JsonConvert.SerializeObject(exception.Errors, Formatting.Indented);
-                log.Info(json);
-            }
-        }
-
-        private async Task ClientOnMessageReceived(SocketMessage socketMessage)
-        {
-            await Task.Run(() =>
-            {
-                // Check if Author is not a bot and allow only reading from the discord LobbyChannel
-                if (!socketMessage.Author.IsBot && socketMessage.Channel.Id == botChannelId && !socketMessage.Author.IsWebhook)
-                {
-                    ChatNotification message = new ChatNotification
-                    {
-                        SenderHandle = $"(Discord) {socketMessage.Author.Username}",
-                        ConsoleMessageType = ConsoleMessageType.GlobalChat,
-                        Text = socketMessage.Content,
-                    };
-                    foreach (long playerAccountId in SessionManager.GetOnlinePlayers())
-                    {
-                        LobbyServerProtocol player = SessionManager.GetClientConnection(playerAccountId);
-                        if (player != null && player.CurrentServer == null)
-                        {
-                            player.Send(message);
-                        }
-                    }
-                }
-            });
-        }
-
-        private async Task SlashCommandHandler(SocketSlashCommand command)
-        {
-            if (command.Data.Name == "info")
-            {
-                DiscordLobbyUtils.Status status = DiscordLobbyUtils.GetStatus();
-                await command.RespondAsync(embed:
-                                new EmbedBuilder
-                                {
-                                    Title = DiscordLobbyUtils.BuildPlayerCountSummary(status),
-                                    Color = Color.Green
-                                }.Build(), ephemeral: true);
-            }
-            if (command.Data.Name == "broadcast")
-            {
-                ChatNotification message = new ChatNotification
-                {
-                    SenderHandle = command.User.Username,
-                    ConsoleMessageType = ConsoleMessageType.BroadcastMessage,
-                    Text = command.Data.Options.First().Value.ToString(),
-                };
-                foreach (long playerAccountId in SessionManager.GetOnlinePlayers())
-                {
-                    LobbyServerProtocol player = SessionManager.GetClientConnection(playerAccountId);
-                    if (player != null)
-                    {
-                        player.Send(message);
-                    }
-                }
-                await command.RespondAsync("Broadcast send", ephemeral: true);
-            }
         }
 
         private static Task Log(LogMessage msg)

--- a/LobbyServer2/LobbyServer/Discord/DiscordClientWrapper.cs
+++ b/LobbyServer2/LobbyServer/Discord/DiscordClientWrapper.cs
@@ -1,8 +1,15 @@
 using System.Collections.Generic;
+using System.Linq;
 using System.Threading.Tasks;
+using CentralServer.LobbyServer.Session;
 using Discord;
+using Discord.Net;
 using Discord.Webhook;
+using Discord.WebSocket;
+using EvoS.Framework.Constants.Enums;
+using EvoS.Framework.Network.NetworkMessages;
 using log4net;
+using Newtonsoft.Json;
 
 namespace CentralServer.LobbyServer.Discord
 {
@@ -11,6 +18,12 @@ namespace CentralServer.LobbyServer.Discord
         private static readonly ILog log = LogManager.GetLogger(typeof(DiscordClientWrapper));
         
         private readonly DiscordWebhookClient client;
+        private readonly DiscordSocketClient botClient;
+        private static readonly DiscordSocketConfig discordConfig = new DiscordSocketConfig
+        {
+            GatewayIntents = GatewayIntents.AllUnprivileged | GatewayIntents.MessageContent
+        };
+        private readonly ulong? botChannelId;
         private readonly ulong? threadId;
         
         public DiscordClientWrapper(DiscordChannel conf)
@@ -18,6 +31,100 @@ namespace CentralServer.LobbyServer.Discord
             client = new DiscordWebhookClient(conf.Webhook);
             client.Log += Log;
             threadId = conf.ThreadId;
+        }
+
+        public DiscordClientWrapper(DiscordConfiguration conf)
+        {
+            botClient = new DiscordSocketClient(discordConfig);
+            botChannelId = conf.BotChannelId;
+            botClient.LoginAsync(TokenType.Bot, conf.BotToken);
+            botClient.StartAsync();
+            botClient.SetGameAsync("Atlas Reactor");
+            botClient.Log += Log;
+            botClient.Ready += Ready;
+            botClient.SlashCommandExecuted += SlashCommandHandler;
+            botClient.MessageReceived += ClientOnMessageReceived;
+        }
+
+        public async Task Ready()
+        {
+            SlashCommandBuilder infoCommand = new SlashCommandBuilder();
+            infoCommand.WithName("info");
+            infoCommand.WithDescription("Retrieve info from Atlas Reactor");
+
+            SlashCommandBuilder broadcastCommand = new SlashCommandBuilder();
+            broadcastCommand.WithName("broadcast");
+            broadcastCommand.WithDescription("Send a broadcast to atlas reactor lobby");
+            broadcastCommand.AddOption("message", ApplicationCommandOptionType.String, "Message to send", true);
+            broadcastCommand.WithDefaultMemberPermissions(GuildPermission.ManageGuild);
+
+            try
+            {
+                await botClient.CreateGlobalApplicationCommandAsync(infoCommand.Build());
+                await botClient.CreateGlobalApplicationCommandAsync(broadcastCommand.Build());
+            }
+            catch (HttpException exception)
+            {
+                var json = JsonConvert.SerializeObject(exception.Errors, Formatting.Indented);
+                log.Info(json);
+            }
+        }
+
+        private async Task ClientOnMessageReceived(SocketMessage socketMessage)
+        {
+            await Task.Run(() =>
+            {
+                // Check if Author is not a bot and allow only reading from the discord LobbyChannel
+                if (!socketMessage.Author.IsBot && socketMessage.Channel.Id == botChannelId && !socketMessage.Author.IsWebhook)
+                {
+                    ChatNotification message = new ChatNotification
+                    {
+                        SenderHandle = $"(Discord) {socketMessage.Author.Username}",
+                        ConsoleMessageType = ConsoleMessageType.GlobalChat,
+                        Text = socketMessage.Content,
+                    };
+                    foreach (long playerAccountId in SessionManager.GetOnlinePlayers())
+                    {
+                        LobbyServerProtocol player = SessionManager.GetClientConnection(playerAccountId);
+                        if (player != null && player.CurrentServer == null)
+                        {
+                            player.Send(message);
+                        }
+                    }
+                }
+            });
+        }
+
+        private async Task SlashCommandHandler(SocketSlashCommand command)
+        {
+            if (command.Data.Name == "info")
+            {
+                DiscordLobbyUtils.Status status = DiscordLobbyUtils.GetStatus();
+                await command.RespondAsync(embed:
+                                new EmbedBuilder
+                                {
+                                    Title = DiscordLobbyUtils.BuildPlayerCountSummary(status),
+                                    Color = Color.Green
+                                }.Build(), ephemeral: true);
+            }
+            if (command.Data.Name == "broadcast")
+            {
+                ChatNotification message = new ChatNotification
+                {
+                    SenderHandle = command.User.Username,
+                    ConsoleMessageType = ConsoleMessageType.BroadcastMessage,
+                    Text = command.Data.Options.First().Value.ToString(),
+                };
+                foreach (long playerAccountId in SessionManager.GetOnlinePlayers())
+                {
+                    LobbyServerProtocol player = SessionManager.GetClientConnection(playerAccountId);
+                    if (player != null)
+                    {
+                        player.Send(message);
+                    }
+                }
+                await command.RespondAsync("Broadcast send", ephemeral: true);
+            }
         }
 
         private static Task Log(LogMessage msg)

--- a/LobbyServer2/LobbyServer/Discord/DiscordConfiguration.cs
+++ b/LobbyServer2/LobbyServer/Discord/DiscordConfiguration.cs
@@ -10,6 +10,10 @@ namespace CentralServer.LobbyServer.Discord
         public DiscordChannel GameLogChannel;
         public DiscordChannel LobbyChannel;
 
+        public string BotToken = "";
+        public ulong? BotChannelId;
+        public bool UseDiscordBot;
+
         public bool AdminEnableUserReports;
         public ulong? AdminUserReportThreadId;
         public bool AdminEnableChatAudit;

--- a/LobbyServer2/LobbyServer/Discord/DiscordManager.cs
+++ b/LobbyServer2/LobbyServer/Discord/DiscordManager.cs
@@ -29,7 +29,8 @@ namespace CentralServer.LobbyServer.Discord
         private readonly DiscordClientWrapper gameLogChannel;
         private readonly DiscordClientWrapper adminChannel;
         private readonly DiscordClientWrapper lobbyChannel;
-        
+        private readonly DiscordClientWrapper discordBot;
+
         private readonly CancellationTokenSource cancelTokenSource = new CancellationTokenSource();
 
         private static readonly DiscordLobbyUtils.Status NO_STATUS = new DiscordLobbyUtils.Status { totalPlayers = -1, inGame = -1, inQueue = -1 };
@@ -43,6 +44,23 @@ namespace CentralServer.LobbyServer.Discord
             {
                 log.Info("Discord is not enabled");
                 return;
+            }
+
+            if (!conf.UseDiscordBot)
+            {
+                log.Info("Discord bot is not enabled");
+            }
+            else 
+            {
+                if (conf.BotToken.IsNullOrEmpty() || conf.BotToken.Length < 70 || !conf.BotChannelId.HasValue || conf.BotChannelId == 0)
+                {
+                    log.Info("Discord bot is not configured correctly");
+                } 
+                else
+                {
+                    // Init bot but we dont use it for anything not yet anyway we just want chat from discord to atlas and commands
+                    discordBot = new DiscordClientWrapper(conf);
+                }
             }
 
             if (conf.GameLogChannel.IsChannel())

--- a/LobbyServer2/LobbyServer/Discord/DiscordManager.cs
+++ b/LobbyServer2/LobbyServer/Discord/DiscordManager.cs
@@ -29,7 +29,7 @@ namespace CentralServer.LobbyServer.Discord
         private readonly DiscordClientWrapper gameLogChannel;
         private readonly DiscordClientWrapper adminChannel;
         private readonly DiscordClientWrapper lobbyChannel;
-        private readonly DiscordClientWrapper discordBot;
+        private readonly DiscordBotWrapper discordBot;
 
         private readonly CancellationTokenSource cancelTokenSource = new CancellationTokenSource();
 
@@ -59,7 +59,7 @@ namespace CentralServer.LobbyServer.Discord
                 else
                 {
                     // Init bot but we dont use it for anything not yet anyway we just want chat from discord to atlas and commands
-                    discordBot = new DiscordClientWrapper(conf);
+                    discordBot = new DiscordBotWrapper(conf);
                 }
             }
 


### PR DESCRIPTION
Add a way for people to chat to Atlas Reactor from discord adds 2 commands /info and /broadcast
 - /info returns the current players online - que - ingame
 - /broadcast allows to send a broadcast to lobby to all players (Needs  ManageGuild permission to be able to use) handy to notify users Aka server restart etc..

We keep webhooks cause they allows us to have a nicer discord chat from AR and have different icons for different things can't do that with pure bot

Create a bot at : https://discord.com/developers/applications Then invite the bot to the server
`https://discord.com/oauth2/authorize?client_id=<APPLICATION ID>&permissions=0&scope=bot%20applications.commands`
Replace APPLICATION ID with id found in developers section of the bot make sure to give the bot the permission MESSAGE CONTENT INTENT in the section "Bot" to be able to read messages

Update webhook version