### PR TITLE
Fix GGBoosts.

### DIFF
--- a/LobbyServer2/BridgeServer/BridgeServerProtocol.cs
+++ b/LobbyServer2/BridgeServer/BridgeServerProtocol.cs
@@ -324,14 +324,8 @@ namespace CentralServer.BridgeServer
 
         public void OnPlayerUsedGGPack(long accountId)
         {
-            int ggPackUsedAccountIDs = 0;
-            GameInfo.ggPackUsedAccountIDs.TryGetValue(accountId, out ggPackUsedAccountIDs);
+            GameInfo.ggPackUsedAccountIDs.TryGetValue(accountId, out int ggPackUsedAccountIDs);
             GameInfo.ggPackUsedAccountIDs[accountId] = ggPackUsedAccountIDs + 1;
-
-            // *EDGE CASE* Set to true to keep all current game characters
-            // Incase someone leaves a match and changes there character,banners etc..,
-            // make sure we have the old character data and not the new character data for this state
-            SendGameInfoNotifications(true);
         }
 
         public bool IsAvailable()

--- a/LobbyServer2/LobbyServer/LobbyServerProtocol.cs
+++ b/LobbyServer2/LobbyServer/LobbyServerProtocol.cs
@@ -54,8 +54,6 @@ namespace CentralServer.LobbyServer
 
         public CharacterType OldCharacter { get; set; }
         
-        public int UsedGGBoostsCount { get; set; }
-        
         public event Action<LobbyServerProtocol, ChatNotification> OnChatNotification = delegate {};
         public event Action<LobbyServerProtocol, GroupChatRequest> OnGroupChatRequest = delegate {};
         
@@ -931,10 +929,10 @@ namespace CentralServer.LobbyServer
                 ResponseId = request.RequestId
             };
             Send(response);
-            UsedGGBoostsCount++;
 
             if (CurrentServer != null)
             {
+                CurrentServer.OnPlayerUsedGGPack(AccountId);
                 foreach (LobbyServerProtocol client in CurrentServer.GetClients())
                 {
                     if (client.AccountId != AccountId)
@@ -947,11 +945,11 @@ namespace CentralServer.LobbyServer
                             GGPackUserRibbon = account.AccountComponent.SelectedRibbonID,
                             GGPackUserTitle = account.AccountComponent.SelectedTitleID,
                             GGPackUserTitleLevel = 1,
-                            NumGGPacksUsed = UsedGGBoostsCount
+                            NumGGPacksUsed = CurrentServer.GameInfo.ggPackUsedAccountIDs[AccountId]
                         };
                         client.Send(useGGPackNotification);
                     }
-                    CurrentServer.OnPlayerUsedGGPack(AccountId);
+                    
                 }
             }
         }

--- a/LobbyServer2/LobbyServer/LobbyServerProtocol.cs
+++ b/LobbyServer2/LobbyServer/LobbyServerProtocol.cs
@@ -54,6 +54,7 @@ namespace CentralServer.LobbyServer
 
         public CharacterType OldCharacter { get; set; }
         
+        public int UsedGGBoostsCount { get; set; }
         
         public event Action<LobbyServerProtocol, ChatNotification> OnChatNotification = delegate {};
         public event Action<LobbyServerProtocol, GroupChatRequest> OnGroupChatRequest = delegate {};
@@ -921,7 +922,7 @@ namespace CentralServer.LobbyServer
             PersistedAccountData account = DB.Get().AccountDao.GetAccount(AccountId);
             UseGGPackResponse response = new UseGGPackResponse()
             {
-                GGPackUserName = account.UserName,
+                GGPackUserName = account.Handle,
                 GGPackUserBannerBackground = account.AccountComponent.SelectedBackgroundBannerID,
                 GGPackUserBannerForeground = account.AccountComponent.SelectedForegroundBannerID,
                 GGPackUserRibbon = account.AccountComponent.SelectedRibbonID,
@@ -930,21 +931,23 @@ namespace CentralServer.LobbyServer
                 ResponseId = request.RequestId
             };
             Send(response);
+            UsedGGBoostsCount++;
 
             if (CurrentServer != null)
             {
-                foreach(LobbyServerProtocol client in CurrentServer.GetClients())
+                foreach (LobbyServerProtocol client in CurrentServer.GetClients())
                 {
                     if (client.AccountId != AccountId)
                     {
                         UseGGPackNotification useGGPackNotification = new UseGGPackNotification()
                         {
-                            GGPackUserName = account.UserName,
+                            GGPackUserName = account.Handle,
                             GGPackUserBannerBackground = account.AccountComponent.SelectedBackgroundBannerID,
                             GGPackUserBannerForeground = account.AccountComponent.SelectedForegroundBannerID,
                             GGPackUserRibbon = account.AccountComponent.SelectedRibbonID,
                             GGPackUserTitle = account.AccountComponent.SelectedTitleID,
-                            GGPackUserTitleLevel = 1
+                            GGPackUserTitleLevel = 1,
+                            NumGGPacksUsed = UsedGGBoostsCount
                         };
                         client.Send(useGGPackNotification);
                     }

--- a/LobbyServer2/LobbyServer/Matchmaking/MatchmakingManager.cs
+++ b/LobbyServer2/LobbyServer/Matchmaking/MatchmakingManager.cs
@@ -230,6 +230,9 @@ namespace CentralServer.LobbyServer.Matchmaking
             // Assign Current Server
             server.GetClients().ForEach(c => c.CurrentServer = server);
 
+            // Reset UsedGGBoostsCount on each match
+            server.GetClients().ForEach(c => c.UsedGGBoostsCount = 0);
+
             // Store there old CharacterType we set it back when match ends
             // ForcedCharacterChangeFromServerNotification does not persist after a game ends
             // Even tho the server thinks they are another character the client thinks its the previus one

--- a/LobbyServer2/LobbyServer/Matchmaking/MatchmakingManager.cs
+++ b/LobbyServer2/LobbyServer/Matchmaking/MatchmakingManager.cs
@@ -230,9 +230,6 @@ namespace CentralServer.LobbyServer.Matchmaking
             // Assign Current Server
             server.GetClients().ForEach(c => c.CurrentServer = server);
 
-            // Reset UsedGGBoostsCount on each match
-            server.GetClients().ForEach(c => c.UsedGGBoostsCount = 0);
-
             // Store there old CharacterType we set it back when match ends
             // ForcedCharacterChangeFromServerNotification does not persist after a game ends
             // Even tho the server thinks they are another character the client thinks its the previus one


### PR DESCRIPTION
Now there's max to be able to use (client side restriction) also the blue, grey gold tier of GGboosts works, 
the ingame overcon works again when you use GGboosts and the endscreen GGboosts shows who used GGboosts.