### PR TITLE
Use wild card since Dev is translated text

### DIFF
--- a/LobbyServer2/LobbyServer/Chat/ChatManager.cs
+++ b/LobbyServer2/LobbyServer/Chat/ChatManager.cs
@@ -123,7 +123,7 @@ namespace CentralServer.LobbyServer.Chat
                 case ConsoleMessageType.WhisperChat:
                     {
                         // Clean the recipient handle by removing (mentor icon) and (Dev) tag
-                        notification.RecipientHandle = Regex.Replace(notification.RecipientHandle, @"\p{C}|\(Dev\)", "");
+                        notification.RecipientHandle = Regex.Replace(notification.RecipientHandle, @"\p{C}|\(.*?\)", "");
 
                         long? accountId = SessionManager.GetOnlinePlayerByHandle(notification.RecipientHandle);
                         if (accountId.HasValue && accountId.Value != conn.AccountId)

--- a/LobbyServer2/LobbyServer/LobbyServerProtocol.cs
+++ b/LobbyServer2/LobbyServer/LobbyServerProtocol.cs
@@ -1054,7 +1054,7 @@ namespace CentralServer.LobbyServer
         public void HandleGroupInviteRequest(GroupInviteRequest request)
         {
             // Clean the recipient handle by removing (mentor icon) and (Dev) tag
-            request.FriendHandle = Regex.Replace(request.FriendHandle, @"\p{C}|\(Dev\)", "");
+            request.FriendHandle = Regex.Replace(request.FriendHandle, @"\p{C}|\(.*?\)", "");
 
             var response = new GroupInviteResponse
             {


### PR DESCRIPTION
`@"\p{C}|\(Dev\)" =>  @"\p{C}|\(.*?\)`