### PR TITLE
Add Draft Mode!

### DIFF
--- a/EvoS.DirectoryServer/DirectoryServer.cs
+++ b/EvoS.DirectoryServer/DirectoryServer.cs
@@ -385,6 +385,55 @@ namespace EvoS.DirectoryServer
                 willFill.CharacterComponent.LastSelectedLoadout = 0;
             }
 
+            // These are used in Draft in random fill for subcategory
+            // Check if TestFreelancer1 is missing in CharacterData, if it is add it
+            account.CharacterData.TryGetValue(CharacterType.TestFreelancer1, out PersistedCharacterData testFreelancer1);
+            if (testFreelancer1 == null)
+            {
+                account.CharacterData.TryAdd(CharacterType.TestFreelancer1, new PersistedCharacterData(CharacterType.TestFreelancer1));
+                testFreelancer1 = account.CharacterData[CharacterType.TestFreelancer1];
+            }
+
+            // PATCH Make sure testFreelancer1 has default CharacterLoadouts
+            if (testFreelancer1.CharacterComponent.CharacterLoadouts.Count == 0)
+            {
+                testFreelancer1.CharacterComponent.CharacterLoadouts = new List<CharacterLoadout>()
+                {
+                    new CharacterLoadout
+                    (
+                        new CharacterModInfo() { ModForAbility0 = 0, ModForAbility1 = 0, ModForAbility2 = 0, ModForAbility3 = 0, ModForAbility4 = 0 },
+                        new CharacterAbilityVfxSwapInfo() { VfxSwapForAbility0 = 0, VfxSwapForAbility1 = 0, VfxSwapForAbility2 = 0, VfxSwapForAbility3 = 0, VfxSwapForAbility4 = 0 },
+                        "Default",
+                        ModStrictness.AllModes
+                    )
+                };
+                testFreelancer1.CharacterComponent.LastSelectedLoadout = 0;
+            }
+
+            // Check if TestFreelancer1 is missing in CharacterData, if it is add it
+            account.CharacterData.TryGetValue(CharacterType.TestFreelancer2, out PersistedCharacterData testFreelancer2);
+            if (testFreelancer2 == null)
+            {
+                account.CharacterData.TryAdd(CharacterType.TestFreelancer2, new PersistedCharacterData(CharacterType.TestFreelancer2));
+                testFreelancer2 = account.CharacterData[CharacterType.TestFreelancer2];
+            }
+
+            // PATCH Make sure testFreelancer1 has default CharacterLoadouts
+            if (testFreelancer2.CharacterComponent.CharacterLoadouts.Count == 0)
+            {
+                testFreelancer2.CharacterComponent.CharacterLoadouts = new List<CharacterLoadout>()
+                {
+                    new CharacterLoadout
+                    (
+                        new CharacterModInfo() { ModForAbility0 = 0, ModForAbility1 = 0, ModForAbility2 = 0, ModForAbility3 = 0, ModForAbility4 = 0 },
+                        new CharacterAbilityVfxSwapInfo() { VfxSwapForAbility0 = 0, VfxSwapForAbility1 = 0, VfxSwapForAbility2 = 0, VfxSwapForAbility3 = 0, VfxSwapForAbility4 = 0 },
+                        "Default",
+                        ModStrictness.AllModes
+                    )
+                };
+                testFreelancer2.CharacterComponent.LastSelectedLoadout = 0;
+            }
+
             foreach (PersistedCharacterData persistedCharacterData in account.CharacterData.Values)
             {
                 persistedCharacterData.CharacterComponent.UnlockSkinsAndTaunts(persistedCharacterData.CharacterType);

--- a/EvoS.Framework/Network/NetworkMessages/RankedBanRequest.cs
+++ b/EvoS.Framework/Network/NetworkMessages/RankedBanRequest.cs
@@ -1,0 +1,13 @@
+﻿using EvoS.Framework.Network;
+using EvoS.Framework.Network.WebSocket;
+using System;
+
+namespace LobbyGameClientMessages
+{
+    [Serializable]
+    [EvosMessage(207)]
+    public class RankedBanRequest : WebSocketMessage
+    {
+        public CharacterType Selection;
+    }
+}

--- a/EvoS.Framework/Network/NetworkMessages/RankedBanResponse.cs
+++ b/EvoS.Framework/Network/NetworkMessages/RankedBanResponse.cs
@@ -1,0 +1,13 @@
+﻿using EvoS.Framework.Network;
+using EvoS.Framework.Network.WebSocket;
+using System;
+
+namespace LobbyGameClientMessages
+{
+    [Serializable]
+    [EvosMessage(206)]
+    public class RankedBanResponse : WebSocketResponseMessage
+    {
+        public LocalizationPayload LocalizedFailure;
+    }
+}

--- a/EvoS.Framework/Network/NetworkMessages/RankedHoverClickRequest.cs
+++ b/EvoS.Framework/Network/NetworkMessages/RankedHoverClickRequest.cs
@@ -1,0 +1,13 @@
+﻿using EvoS.Framework.Network;
+using EvoS.Framework.Network.WebSocket;
+using System;
+
+namespace LobbyGameClientMessages
+{
+    [Serializable]
+    [EvosMessage(201)]
+    public class RankedHoverClickRequest : WebSocketMessage
+    {
+        public CharacterType Selection;
+    }
+}

--- a/EvoS.Framework/Network/NetworkMessages/RankedHoverClickResponse.cs
+++ b/EvoS.Framework/Network/NetworkMessages/RankedHoverClickResponse.cs
@@ -1,0 +1,13 @@
+﻿using EvoS.Framework.Network;
+using EvoS.Framework.Network.WebSocket;
+using System;
+
+namespace LobbyGameClientMessages
+{
+    [Serializable]
+    [EvosMessage(200)]
+    public class RankedHoverClickResponse : WebSocketResponseMessage
+    {
+        public LocalizationPayload LocalizedFailure;
+    }
+}

--- a/EvoS.Framework/Network/NetworkMessages/RankedSelectionRequest.cs
+++ b/EvoS.Framework/Network/NetworkMessages/RankedSelectionRequest.cs
@@ -1,0 +1,13 @@
+﻿using EvoS.Framework.Network;
+using EvoS.Framework.Network.WebSocket;
+using System;
+
+namespace LobbyGameClientMessages
+{
+    [Serializable]
+    [EvosMessage(205)]
+    public class RankedSelectionRequest : WebSocketMessage
+    {
+        public CharacterType Selection;
+    }
+}

--- a/EvoS.Framework/Network/NetworkMessages/RankedSelectionResponse.cs
+++ b/EvoS.Framework/Network/NetworkMessages/RankedSelectionResponse.cs
@@ -1,0 +1,13 @@
+﻿using EvoS.Framework.Network;
+using EvoS.Framework.Network.WebSocket;
+using System;
+
+namespace LobbyGameClientMessages
+{
+    [Serializable]
+    [EvosMessage(204)]
+    public class RankedSelectionResponse : WebSocketResponseMessage
+    {
+        public LocalizationPayload LocalizedFailure;
+    }
+}

--- a/EvoS.Framework/Network/NetworkMessages/RankedTradeRequest.cs
+++ b/EvoS.Framework/Network/NetworkMessages/RankedTradeRequest.cs
@@ -1,0 +1,14 @@
+﻿using EvoS.Framework.Network;
+using EvoS.Framework.Network.Static;
+using EvoS.Framework.Network.WebSocket;
+using System;
+
+namespace LobbyGameClientMessages
+{
+    [Serializable]
+    [EvosMessage(203)]
+    public class RankedTradeRequest : WebSocketMessage
+    {
+        public RankedTradeData Trade;
+    }
+}

--- a/EvoS.Framework/Network/NetworkMessages/RankedTradeResponse.cs
+++ b/EvoS.Framework/Network/NetworkMessages/RankedTradeResponse.cs
@@ -1,0 +1,13 @@
+﻿using EvoS.Framework.Network;
+using EvoS.Framework.Network.WebSocket;
+using System;
+
+namespace LobbyGameClientMessages
+{
+    [Serializable]
+    [EvosMessage(202)]
+    public class RankedTradeResponse : WebSocketResponseMessage
+    {
+        public LocalizationPayload LocalizedFailure;
+    }
+}

--- a/EvoS.Framework/Network/Static/CharacterComponent.cs
+++ b/EvoS.Framework/Network/Static/CharacterComponent.cs
@@ -185,6 +185,14 @@ namespace EvoS.Framework.Network.Static
                         UnlockSkinPatternColor(0, 0, 0); UnlockSkinPatternColor(0, 0, 1); UnlockSkinPatternColor(0, 0, 2); UnlockSkinPatternColor(0, 0, 3);
                         UnlockSkinPatternColor(1, 0, 0); UnlockSkinPatternColor(1, 0, 1); UnlockSkinPatternColor(1, 0, 2);
                         break;
+                    case CharacterType.TestFreelancer1:
+                        UnlockSkinPatternColor(0, 0, 0); UnlockSkinPatternColor(0, 0, 1); UnlockSkinPatternColor(0, 0, 2); UnlockSkinPatternColor(0, 0, 3);
+                        UnlockSkinPatternColor(1, 0, 0); UnlockSkinPatternColor(1, 0, 1); UnlockSkinPatternColor(1, 0, 2);
+                        break;
+                    case CharacterType.TestFreelancer2:
+                        UnlockSkinPatternColor(0, 0, 0); UnlockSkinPatternColor(0, 0, 1); UnlockSkinPatternColor(0, 0, 2); UnlockSkinPatternColor(0, 0, 3);
+                        UnlockSkinPatternColor(1, 0, 0); UnlockSkinPatternColor(1, 0, 1); UnlockSkinPatternColor(1, 0, 2);
+                        break;
                     case CharacterType.Manta:
                         UnlockSkinPatternColor(0, 0, 0); UnlockSkinPatternColor(0, 0, 1); UnlockSkinPatternColor(0, 0, 2); UnlockSkinPatternColor(0, 0, 3); UnlockSkinPatternColor(0, 0, 4); UnlockSkinPatternColor(0, 0, 5); UnlockSkinPatternColor(0, 0, 6); UnlockSkinPatternColor(0, 0, 7); UnlockSkinPatternColor(0, 0, 8); UnlockSkinPatternColor(0, 0, 9); UnlockSkinPatternColor(0, 0, 10); UnlockSkinPatternColor(0, 0, 11); UnlockSkinPatternColor(0, 0, 12); UnlockSkinPatternColor(0, 0, 13); UnlockSkinPatternColor(0, 0, 14);
                         UnlockSkinPatternColor(1, 0, 0); UnlockSkinPatternColor(1, 0, 1); UnlockSkinPatternColor(1, 0, 2); UnlockSkinPatternColor(1, 0, 3); UnlockSkinPatternColor(1, 0, 4); UnlockSkinPatternColor(1, 0, 5); UnlockSkinPatternColor(1, 0, 6);

--- a/EvoS.Framework/Network/Static/GameSubType.cs
+++ b/EvoS.Framework/Network/Static/GameSubType.cs
@@ -12,7 +12,7 @@ namespace EvoS.Framework.Network.Static
     {
         public GameSubType Clone()
         {
-            GameSubType gameSubType = (GameSubType) MemberwiseClone();
+            GameSubType gameSubType = (GameSubType)MemberwiseClone();
             gameSubType.GameMapConfigs = new List<GameMapConfig>();
             foreach (GameMapConfig gameMapConfig in GameMapConfigs)
             {
@@ -22,8 +22,9 @@ namespace EvoS.Framework.Network.Static
             return gameSubType;
         }
 
-        public GameSubType() {
-            
+        public GameSubType()
+        {
+
         }
 
         public static TimeSpan ConformTurnTimeSpanFromSeconds(double totalSeconds)
@@ -54,6 +55,8 @@ namespace EvoS.Framework.Network.Static
         public PersistedStatBucket PersistedStatBucket;
         public GameBalanceVars.GameRewardBucketType RewardBucket = GameBalanceVars.GameRewardBucketType.NoRewards;
         public TimeSpan LoadoutSelectionTimeoutOverride;
+        [NonSerialized]
+        public bool Bans;
 
         [JsonIgnore]
         public int TeamAHumanPlayers => TeamAPlayers - TeamABots;

--- a/EvoS.Framework/Network/Static/RankedResolutionPhaseData.cs
+++ b/EvoS.Framework/Network/Static/RankedResolutionPhaseData.cs
@@ -1,3 +1,4 @@
+using Newtonsoft.Json;
 using System;
 using System.Collections.Generic;
 
@@ -19,6 +20,20 @@ namespace EvoS.Framework.Network.Static
         [EvosMessage(191)]
         public List<RankedTradeData> TradeActions;
         public List<int> PlayerIdByImporance;
+
+        public RankedResolutionPhaseData Clone()
+        {
+            // Shallow copy the object
+            RankedResolutionPhaseData clone = (RankedResolutionPhaseData)base.MemberwiseClone();
+
+            // Manually deep copy reference types
+            clone.EnemyBans = new List<CharacterType>(EnemyBans);
+            clone.FriendlyBans = new List<CharacterType>(FriendlyBans);
+            clone.EnemyTeamSelections = new Dictionary<int, CharacterType>(EnemyTeamSelections);
+            clone.FriendlyTeamSelections = new Dictionary<int, CharacterType>(FriendlyTeamSelections);
+
+            return clone;
+        }
     }
 
 }

--- a/EvoS.Framework/Network/Static/RankedResolutionPlayerState.cs
+++ b/EvoS.Framework/Network/Static/RankedResolutionPlayerState.cs
@@ -14,8 +14,8 @@ namespace EvoS.Framework.Network.Static
         public enum ReadyState
         {
             Unicode001D,
-            Unicode000E,
-            Unicode0012
+            Unselected,
+            Selected
         }
     }
 }

--- a/EvoS.Framework/Network/Static/RankedTradeData.cs
+++ b/EvoS.Framework/Network/Static/RankedTradeData.cs
@@ -15,9 +15,9 @@ namespace EvoS.Framework.Network.Static
         [EvosMessage(194)]
         public enum TradeActionType
         {
-            Unicode001D,
-            Unicode000E,
-            Unicode0012
+            AcceptOrOffer,
+            Reject,
+            StopTrading
         }
     }
 }

--- a/EvoS.Framework/Server/Characters/CharacterConfigs.cs
+++ b/EvoS.Framework/Server/Characters/CharacterConfigs.cs
@@ -474,6 +474,32 @@ namespace CentralServer.LobbyServer.Character
                     GameTypesProhibitedFrom = new List<GameType>(),
                     IsHidden = false
                 }
+            },
+            {
+                CharacterType.TestFreelancer1,
+                new CharacterConfig()
+                {
+                    AllowForBots = false,
+                    AllowForPlayers = true,
+                    CharacterRole = CharacterRole.None,
+                    CharacterType = CharacterType.TestFreelancer1,
+                    Difficulty = 1,
+                    GameTypesProhibitedFrom = new List<GameType>(),
+                    IsHidden = false // does show but it is disabled for bots GameTypesProhibitedFrom does not add it as hidden just disabled but we already set AllowForBots to false, it only shows in custom
+                }
+            },
+            {
+                CharacterType.TestFreelancer2,
+                new CharacterConfig()
+                {
+                    AllowForBots = false,
+                    AllowForPlayers = true,
+                    CharacterRole = CharacterRole.None,
+                    CharacterType = CharacterType.TestFreelancer2,
+                    Difficulty = 1,
+                    GameTypesProhibitedFrom = new List<GameType>(),
+                    IsHidden = false // does show but it is disabled for bots GameTypesProhibitedFrom does not add it as hidden just disabled but we already set AllowForBots to false, it only shows in custom
+                }
             }
         };
     }

--- a/LobbyServer2/BridgeServer/Game.cs
+++ b/LobbyServer2/BridgeServer/Game.cs
@@ -195,7 +195,7 @@ public abstract class Game
 
     protected async void OnServerDisconnect(BridgeServerProtocol server)
     {
-        if (GameStatus < GameStatus.Started) {
+        if (GameStatus > GameStatus.Started) {
             QueuePenaltyManager.CapQueuePenalties(this);
         }
 

--- a/LobbyServer2/BridgeServer/Game.cs
+++ b/LobbyServer2/BridgeServer/Game.cs
@@ -1202,7 +1202,10 @@ public abstract class Game
         {
             usedCharacterTypes.UnionWith(botCharacters);
             characterType = AssignRandomCharacterForDraft(player, usedCharacterTypes);
-            if (PhaseSubType == FreelancerResolutionPhaseSubType.PICK_FREELANCER1 || PhaseSubType == FreelancerResolutionPhaseSubType.PICK_FREELANCER2)
+            if (PhaseSubType == FreelancerResolutionPhaseSubType.PICK_BANS1
+                || PhaseSubType == FreelancerResolutionPhaseSubType.PICK_BANS2
+                || PhaseSubType == FreelancerResolutionPhaseSubType.PICK_FREELANCER1
+                || PhaseSubType == FreelancerResolutionPhaseSubType.PICK_FREELANCER2)
             {
                 int index = RankedResolutionPhaseData.UnselectedPlayerStates.FindIndex(p => p.PlayerId == player.PlayerId);
                 if (index < 0)
@@ -1215,6 +1218,7 @@ public abstract class Game
                 state.Intention = characterType;
                 RankedResolutionPhaseData.UnselectedPlayerStates[index] = state;
                 botCharacters.Add(characterType);
+                // TODO Update bot name when it picks a character to play (not to ban)
             }
         }
 #if DEBUG

--- a/LobbyServer2/BridgeServer/Game.cs
+++ b/LobbyServer2/BridgeServer/Game.cs
@@ -1,10 +1,12 @@
 using System;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.Linq;
 using System.Threading.Tasks;
 using CentralServer.LobbyServer;
 using CentralServer.LobbyServer.Character;
 using CentralServer.LobbyServer.Discord;
+using CentralServer.LobbyServer.Gamemode;
 using CentralServer.LobbyServer.Matchmaking;
 using CentralServer.LobbyServer.Session;
 using CentralServer.LobbyServer.Stats;
@@ -40,6 +42,15 @@ public abstract class Game
 
     public string ProcessCode => GameInfo?.GameServerProcessCode;
     public GameStatus GameStatus => GameInfo?.GameStatus ?? GameStatus.None;
+
+    // Draft
+    private RankedResolutionPhaseData RankedResolutionPhaseData = new();
+    private TimeSpan TimeLeftInSubPhase = new();
+    private bool isCancellationRequested = false;
+    private FreelancerResolutionPhaseSubType PhaseSubType = FreelancerResolutionPhaseSubType.UNDEFINED;
+    private Team CurrentTeam = Team.TeamA;
+    public int PlayersInDeck { protected set; get; }
+    private List<CharacterType> botCharacters = new();
 
     public void AssignServer(BridgeServerProtocol server)
     {
@@ -184,7 +195,9 @@ public abstract class Game
 
     protected async void OnServerDisconnect(BridgeServerProtocol server)
     {
-        QueuePenaltyManager.CapQueuePenalties(this);
+        if (GameStatus < GameStatus.Started) {
+            QueuePenaltyManager.CapQueuePenalties(this);
+        }
 
         await Task.Delay(LobbyConfiguration.GetServerReconnectionTimeout());
         if (Server == server && GameStatus != GameStatus.Stopped)
@@ -687,11 +700,16 @@ public abstract class Game
 
                 bool allowDuplicates = GameInfo.GameConfig.HasGameOption(GameOptionFlag.AllowDuplicateCharacters);
                 List<LobbyServerPlayerInfo> playersRequiredToSwitch = characters
-                    .Where(players => !allowDuplicates && players.Count() > 1 && players.Key != CharacterType.PendingWillFill)
+                    .Where(players => !allowDuplicates && players.Count() > 1 
+                            && players.Key != CharacterType.PendingWillFill 
+                            && players.Key != CharacterType.TestFreelancer1
+                            && players.Key != CharacterType.TestFreelancer2)
                     .SelectMany(players => players.Skip(1))
                     .Concat(
                         characters
-                            .Where(players => players.Key == CharacterType.PendingWillFill)
+                            .Where(players => players.Key == CharacterType.PendingWillFill
+                                                || players.Key == CharacterType.TestFreelancer1
+                                                || players.Key == CharacterType.TestFreelancer2)
                             .SelectMany(players => players))
                     .ToList();
 
@@ -863,6 +881,67 @@ public abstract class Game
         return randomType;
     }
 
+    public CharacterType AssignRandomCharacterForDraft(
+        LobbyServerPlayerInfo playerInfo,
+        List<CharacterType> unavailableCharacters,
+        CharacterType preferedCat = CharacterType.Gryd)
+    {
+        CharacterRole characterRole = CharacterRole.None;
+
+        if (preferedCat != CharacterType.Gryd)
+        {
+            switch (preferedCat)
+            {
+                case CharacterType.PendingWillFill:
+                    characterRole = CharacterRole.Assassin;
+                    break;
+                case CharacterType.TestFreelancer1:
+                    characterRole = CharacterRole.Tank;
+                    break;
+                case CharacterType.TestFreelancer2:
+                    characterRole = CharacterRole.Support;
+                    break;
+            }
+        }
+
+        List<CharacterType> availableTypes;
+
+        if (preferedCat != CharacterType.Gryd)
+        {
+            // Select only characters that match the specified characterRole (from preferedCat)
+            availableTypes = CharacterConfigs.Characters
+                .Where(cc =>
+                    cc.Value.AllowForPlayers
+                    && cc.Value.CharacterRole == characterRole
+                    && !unavailableCharacters.Contains(cc.Key))
+                .Select(cc => cc.Key)
+                .ToList();
+        }
+        else
+        {
+            // Select all available characters (ignoring the preferedCat)
+            availableTypes = CharacterConfigs.Characters
+                .Where(cc =>
+                    cc.Value.AllowForPlayers
+                    && cc.Value.CharacterRole != CharacterRole.None
+                    && !unavailableCharacters.Contains(cc.Key))
+                .Select(cc => cc.Key)
+                .ToList();
+        }
+
+        // Shuffle the availableTypes list
+        Random rand = new Random();
+        CharacterType randomType = availableTypes[rand.Next(availableTypes.Count)];
+
+        log.Info($"Selected random character {randomType} for {playerInfo.Handle} " +
+                 $"(was {playerInfo.CharacterType}), options were {string.Join(", ", availableTypes)}, " +
+                 $"used characters: {string.Join(", ", unavailableCharacters)})");
+
+        return randomType;
+    }
+
+
+
     private void NotifyCharacterChange(LobbyServerProtocol playerConnection, LobbyServerPlayerInfo playerInfo, CharacterType randomType)
     {
         PersistedAccountData account = DB.Get().AccountDao.GetAccount(playerInfo.AccountId);
@@ -906,5 +985,392 @@ public abstract class Game
         Server.StartGameForReconnection(conn.AccountId);
 
         return true;
+    }
+
+    public async Task HandleRankedResolutionPhase()
+    {
+        // Add RankedFreelancerSelection in any of the GameSubTypes to enable drafting
+        if (!GameSubType.Mods.Contains(GameSubType.SubTypeMods.RankedFreelancerSelection))
+            return;
+
+        // Initialize unselected player states
+        var unselectedPlayerStates = TeamInfo.TeamPlayerInfo.Select(player =>
+            new RankedResolutionPlayerState
+            {
+                PlayerId = player.PlayerId,
+                Intention = CharacterType.None,
+                OnDeckness = RankedResolutionPlayerState.ReadyState.Unselected,
+            }).ToList();
+
+        // Initialize ranked resolution phase data
+        RankedResolutionPhaseData = new RankedResolutionPhaseData
+        {
+            TimeLeftInSubPhase = TimeSpan.Zero,
+            UnselectedPlayerStates = unselectedPlayerStates,
+            PlayersOnDeck = new List<RankedResolutionPlayerState>(),
+            FriendlyBans = new List<CharacterType>(),
+            EnemyBans = new List<CharacterType>(),
+            FriendlyTeamSelections = new Dictionary<int, CharacterType>(),
+            EnemyTeamSelections = new Dictionary<int, CharacterType>(),
+            TradeActions = new List<RankedTradeData>(),
+            PlayerIdByImporance = TeamInfo.TeamPlayerInfo.Select(p => p.PlayerId).ToList(),
+        };
+
+        // Define phase order
+        // Bans can be disabled if they are disable client wont show ban windows (Due to poll of favoring bans add a setting to Custom to disable bans only there)
+        // -1 for other fases where we dont need the player (trade)
+        // Teams NEED to be min 8 and max 8 only
+        List<KeyValuePair<int, FreelancerResolutionPhaseSubType>> phases;
+        string localizedName = GameSubType.LocalizedName;
+        bool hasBans = GameModeManager.GetBans(localizedName);
+        if (hasBans)
+        {
+            phases = new()
+            {
+                // Playerid (-1)                           Phase
+                new(0, FreelancerResolutionPhaseSubType.PICK_BANS1),    // TeamA First Person
+                new(4, FreelancerResolutionPhaseSubType.PICK_BANS1),    // TeamB First Person
+                new(0, FreelancerResolutionPhaseSubType.PICK_FREELANCER1),  // TeamA First Person
+                new(4, FreelancerResolutionPhaseSubType.PICK_FREELANCER2),  // TeamB * 2 First and Second Person
+                new(1, FreelancerResolutionPhaseSubType.PICK_FREELANCER1),  // TeamA Second Person
+                new(5, FreelancerResolutionPhaseSubType.PICK_BANS2),    // TeamB Second Person
+                new(1, FreelancerResolutionPhaseSubType.PICK_BANS2),    // TeamA Second Person
+                new(6, FreelancerResolutionPhaseSubType.PICK_FREELANCER1),  // TeamB Third Person
+                new(2, FreelancerResolutionPhaseSubType.PICK_FREELANCER2),  // TeamA * 2 Third and Fourth Person
+                new(7, FreelancerResolutionPhaseSubType.PICK_FREELANCER1),  // TeamB Fourth Person
+                new(-1, FreelancerResolutionPhaseSubType.FREELANCER_TRADE),
+            };
+        }
+        else
+        {
+            phases = new()
+            {
+                new(0, FreelancerResolutionPhaseSubType.PICK_FREELANCER1),  // TeamA First Person
+                new(4, FreelancerResolutionPhaseSubType.PICK_FREELANCER2),  // TeamB * 2 First and Second Person
+                new(1, FreelancerResolutionPhaseSubType.PICK_FREELANCER1),  // TeamA Second Person
+                new(6, FreelancerResolutionPhaseSubType.PICK_FREELANCER1),  // TeamB Third Person
+                new(2, FreelancerResolutionPhaseSubType.PICK_FREELANCER2),  // TeamA * 2 Third and Fourth Person
+                new(7, FreelancerResolutionPhaseSubType.PICK_FREELANCER1),  // TeamB Fourth Person
+                new(-1, FreelancerResolutionPhaseSubType.FREELANCER_TRADE),
+            };
+        }
+
+
+        // Process each phase
+        foreach (KeyValuePair<int, FreelancerResolutionPhaseSubType> subPhase in phases)
+        {
+            if (!CheckIfAllParticipantsAreConnected())
+            {
+                return;
+            }
+
+            PhaseSubType = subPhase.Value;
+
+            LobbyServerPlayerInfo player1 = GetPlayerInfo(subPhase.Key, TeamInfo.TeamPlayerInfo);
+            LobbyServerPlayerInfo player2 = GetPlayerInfo(subPhase.Key + 1, TeamInfo.TeamPlayerInfo);
+
+            if (PhaseSubType == FreelancerResolutionPhaseSubType.FREELANCER_TRADE || player1 == null)
+            {
+                // Mostly when subPhase.Key is -1 (FREELANCER_TRADE) we still need a player1
+                player1 = new LobbyServerPlayerInfo();
+            }
+
+            RankedResolutionPhaseData.PlayersOnDeck.Clear(); // Reset deck (People who can do stuff, ban or select a freelancer those are the PlayersOnDeck)
+            // Clear botCharacters so we can start using it again this is for when using bots and we have 2 players on deck we dont want them to accendently pick same character
+            botCharacters.Clear();
+            PlayersInDeck = 0;
+            if (subPhase.Key != -1)
+            {
+                AddPlayersToDeckBasedOnPhase(PhaseSubType, player1, player2);
+            }
+
+            SendRankedResolutionSubPhase();
+            await HandleRankedResolutionSubPhase(PhaseSubType, CurrentTeam, player1);
+
+            foreach (RankedResolutionPlayerState playersInDeck in RankedResolutionPhaseData.PlayersOnDeck)
+            {
+                LobbyServerPlayerInfo player = GetPlayerInfo(playersInDeck.PlayerId - 1, TeamInfo.TeamPlayerInfo);
+                if (playersInDeck.Intention == CharacterType.None)
+                {
+                    // Cancel Match AFK Player
+                    CancelMatch(player.Handle);
+                    // TODO: Punish Player
+                    return;
+                }
+                // Selected is when did not lock in or clicked ban button
+                if (playersInDeck.OnDeckness == RankedResolutionPlayerState.ReadyState.Selected)
+                {
+                    CharacterType characterType = playersInDeck.Intention;
+                    //Player selected fill but did not locked in, or edge case where "MAYBE" we still have fill
+                    if (characterType == CharacterType.PendingWillFill
+                        || characterType == CharacterType.TestFreelancer1
+                        || characterType == CharacterType.TestFreelancer2)
+                    {
+                        List<CharacterType> usedCharacterTypes = new();
+                        usedCharacterTypes.AddRange(RankedResolutionPhaseData.FriendlyBans);
+                        usedCharacterTypes.AddRange(RankedResolutionPhaseData.EnemyBans);
+                        usedCharacterTypes.AddRange(RankedResolutionPhaseData.FriendlyTeamSelections.Values);
+                        usedCharacterTypes.AddRange(RankedResolutionPhaseData.EnemyTeamSelections.Values);
+                        characterType = AssignRandomCharacterForDraft(player, usedCharacterTypes, characterType);
+                    }
+
+                    if (PhaseSubType == FreelancerResolutionPhaseSubType.PICK_BANS1
+                        || PhaseSubType == FreelancerResolutionPhaseSubType.PICK_BANS2)
+                    {
+                        AddToTeamBanSelection(characterType);
+                    }
+                    else if (PhaseSubType == FreelancerResolutionPhaseSubType.PICK_FREELANCER1
+                             || PhaseSubType == FreelancerResolutionPhaseSubType.PICK_FREELANCER2)
+                    {
+                        AddToTeamSelection(player, characterType);
+                    }
+                }
+            }
+
+            CurrentTeam = ToggleTeam(CurrentTeam);
+        }
+
+        // Update TeamInfo with new values from rankedResolutionPhaseData.FriendlyTeamSelections
+        UpdateTeamSelection(RankedResolutionPhaseData.FriendlyTeamSelections);
+
+        // Update TeamInfo with new values from rankedResolutionPhaseData.EnemyTeamSelections
+        UpdateTeamSelection(RankedResolutionPhaseData.EnemyTeamSelections);
+
+    }
+
+    private void UpdateTeamSelection(Dictionary<int, CharacterType> selections)
+    {
+        foreach (KeyValuePair<int, CharacterType> selection in selections)
+        {
+            int lobbyServerPlayerInfoIndex = TeamInfo.TeamPlayerInfo.FindIndex(p => p.PlayerId == selection.Key);
+            LobbyServerPlayerInfo playerInfo = TeamInfo.TeamPlayerInfo[lobbyServerPlayerInfoIndex];
+            if (!playerInfo.IsAIControlled)
+            {
+                PersistedAccountData account = DB.Get().AccountDao.GetAccount(playerInfo.AccountId);
+                playerInfo.CharacterInfo = LobbyCharacterInfo.Of(account.CharacterData[selection.Value]);
+            }
+            else
+            {
+                // Update bots handle
+                playerInfo.Handle = selection.Value.ToString();
+                playerInfo.CharacterInfo = new LobbyCharacterInfo
+                {
+                    CharacterType = selection.Value,
+                    CharacterAbilityVfxSwaps = new CharacterAbilityVfxSwapInfo(),
+                    CharacterCards = CharacterCardInfo.MakeDefault(),
+                    CharacterLevel = 1,
+                    CharacterLoadouts = new List<CharacterLoadout>(),
+                    CharacterMatches = 0,
+                    CharacterMods = EvoS.DirectoryServer.Character.CharacterManager.GetDefaultMods(selection.Value),
+                    CharacterSkin = new CharacterVisualInfo(),
+                    CharacterTaunts = new List<PlayerTauntData>()
+                };
+            }
+            
+        }
+    }
+
+
+    private void AddPlayerToDeck(LobbyServerPlayerInfo player)
+    {
+
+        CharacterType characterType = CharacterType.None;
+
+        // Let AI Randomize
+        if (player.IsAIControlled)
+        {
+            List<CharacterType> usedCharacterTypes = new();
+            usedCharacterTypes.AddRange(RankedResolutionPhaseData.FriendlyBans);
+            usedCharacterTypes.AddRange(RankedResolutionPhaseData.EnemyBans);
+            usedCharacterTypes.AddRange(RankedResolutionPhaseData.FriendlyTeamSelections.Values);
+            usedCharacterTypes.AddRange(RankedResolutionPhaseData.EnemyTeamSelections.Values);
+            usedCharacterTypes.AddRange(botCharacters);
+            characterType = AssignRandomCharacterForDraft(player, usedCharacterTypes);
+            if (PhaseSubType == FreelancerResolutionPhaseSubType.PICK_FREELANCER1 || PhaseSubType == FreelancerResolutionPhaseSubType.PICK_FREELANCER2)
+            {
+                RankedResolutionPlayerState unselectedPlayerState = RankedResolutionPhaseData.UnselectedPlayerStates.First(p => p.PlayerId == player.PlayerId);
+                unselectedPlayerState.Intention = characterType;
+                botCharacters.Add(characterType);
+            }
+        }
+#if DEBUG
+        log.Info($"Adding {player.PlayerId} {characterType} on deck ");
+#endif
+        // Add player to the deck with the appropriate state
+        RankedResolutionPhaseData.PlayersOnDeck.Add(new RankedResolutionPlayerState
+        {
+            PlayerId = player.PlayerId,
+            Intention = characterType,
+            OnDeckness = RankedResolutionPlayerState.ReadyState.Selected,
+        });
+
+        // Increment the count of players in the deck (To know when people locked in we can have 2 so we cant just skip a phase if one is locked in and the other is not)
+        PlayersInDeck++;
+    }
+
+    private LobbyServerPlayerInfo GetPlayerInfo(int index, List<LobbyServerPlayerInfo> teamPlayerInfo)
+    {
+        return index >= 0 && index < teamPlayerInfo.Count ? teamPlayerInfo[index] : null;
+    }
+
+    private void AddToTeamSelection(LobbyServerPlayerInfo player, CharacterType characterType)
+    {
+        Dictionary<int, CharacterType> selections = CurrentTeam == Team.TeamA
+            ? RankedResolutionPhaseData.FriendlyTeamSelections
+            : RankedResolutionPhaseData.EnemyTeamSelections;
+
+        selections.Add(player.PlayerId, characterType);
+    }
+
+    private void AddToTeamBanSelection(CharacterType characterType)
+    {
+        List<CharacterType> selections = CurrentTeam == Team.TeamA
+            ? RankedResolutionPhaseData.FriendlyBans
+            : RankedResolutionPhaseData.EnemyBans;
+
+        selections.Add(characterType); // Ban a non existing character just to simulate we NEED things to hapening or client is unhappy and totally breaks
+    }
+
+    // Method to add players to the deck based on the phase type
+    void AddPlayersToDeckBasedOnPhase(FreelancerResolutionPhaseSubType phase, LobbyServerPlayerInfo player1, LobbyServerPlayerInfo player2)
+    {
+        if (phase == FreelancerResolutionPhaseSubType.PICK_BANS1 ||
+            phase == FreelancerResolutionPhaseSubType.PICK_BANS2 ||
+            phase == FreelancerResolutionPhaseSubType.PICK_FREELANCER1)
+        {
+            AddPlayerToDeck(player1);
+        }
+
+        if (phase == FreelancerResolutionPhaseSubType.PICK_FREELANCER2)
+        {
+            AddPlayerToDeck(player1);
+            // Can be null if we are at the last Freelancer selection
+            if (player2 != null)
+            {
+                AddPlayerToDeck(player2);
+            }
+        }
+    }
+
+    private static Team ToggleTeam(Team currentTeam)
+    {
+        return currentTeam == Team.TeamA ? Team.TeamB : Team.TeamA;
+    }
+
+    private async Task HandleRankedResolutionSubPhase(FreelancerResolutionPhaseSubType subPhase, Team currentTeam, LobbyServerPlayerInfo player)
+    {
+#if DEBUG
+        log.Info($"Starting ranked resolution sub phase {subPhase} for Team {currentTeam}");
+#endif
+        RankedResolutionPhaseData pickPhaseData = new()
+        {
+            TimeLeftInSubPhase = GetSubPhaseTimeout(subPhase)
+        };
+
+        TimeLeftInSubPhase = pickPhaseData.TimeLeftInSubPhase;
+        SendRankedResolutionSubPhase();
+
+        isCancellationRequested = false;
+
+        await MonitorSubPhaseAsync(pickPhaseData.TimeLeftInSubPhase, player);
+    }
+
+    private TimeSpan GetSubPhaseTimeout(FreelancerResolutionPhaseSubType subPhase) =>
+        subPhase switch
+        {
+            FreelancerResolutionPhaseSubType.PICK_BANS1 => GameInfo.SelectSubPhaseBan1Timeout,
+            FreelancerResolutionPhaseSubType.PICK_BANS2 => GameInfo.SelectSubPhaseBan2Timeout,
+            FreelancerResolutionPhaseSubType.PICK_FREELANCER1 => GameInfo.SelectSubPhaseFreelancerSelectTimeout,
+            FreelancerResolutionPhaseSubType.PICK_FREELANCER2 => GameInfo.SelectSubPhaseFreelancerSelectTimeout,
+            FreelancerResolutionPhaseSubType.FREELANCER_TRADE => GameInfo.SelectSubPhaseTradeTimeout,
+            _ => throw new ArgumentOutOfRangeException(nameof(subPhase), subPhase, "Invalid sub phase type")
+        };
+
+    private async Task MonitorSubPhaseAsync(TimeSpan timeLeftInSubPhase, LobbyServerPlayerInfo player)
+    {
+        Stopwatch stopwatch = Stopwatch.StartNew();
+        TimeSpan botCheckInterval = TimeSpan.FromSeconds(5);
+
+        while (stopwatch.Elapsed <= timeLeftInSubPhase)
+        {
+            if (isCancellationRequested)
+            {
+#if DEBUG
+                log.Info($"Cancellation requested. Exiting sub-phase monitoring for player {player.PlayerId}.");
+#endif
+                return;
+            }
+
+            if (!player.IsHumanControlled && stopwatch.Elapsed > botCheckInterval)
+            {
+#if DEBUG
+                log.Info($"AI-controlled player {player.PlayerId} has been checked after {botCheckInterval.TotalSeconds} seconds. Exiting sub-phase early.");
+#endif
+                return;
+            }
+
+
+            TimeLeftInSubPhase = timeLeftInSubPhase - stopwatch.Elapsed;
+            await Task.Delay(100);
+        }
+
+#if DEBUG
+        log.Info($"Sub-phase monitoring complete for player {player.PlayerId} after {stopwatch.Elapsed.TotalSeconds} seconds.");
+#endif
+    }
+
+    // When a player locks in kill the timer
+    public void SkipRankedResolutionSubPhase()
+    {
+        isCancellationRequested = true;
+    }
+
+    public void SetRankedResolutionPhaseData(RankedResolutionPhaseData newRankedResolutionPhaseData)
+    {
+        RankedResolutionPhaseData = newRankedResolutionPhaseData;
+    }
+
+    public RankedResolutionPhaseData GetRankedResolutionPhaseData()
+    {
+        return RankedResolutionPhaseData;
+    }
+
+    public void UpdatePlayersInDeck()
+    {
+        PlayersInDeck--;
+    }
+
+    public void SendRankedResolutionSubPhase()
+    {
+        RankedResolutionPhaseData.TimeLeftInSubPhase = TimeLeftInSubPhase;
+
+
+        GetClients().ForEach(c =>
+        {
+            LobbyServerPlayerInfo player = GetPlayerInfo(c.AccountId);
+
+            // Clone the data for each player to prevent data sharing between players
+            RankedResolutionPhaseData rankedResolutionPhaseDataClone = RankedResolutionPhaseData.Clone();
+
+
+            // Client always thinks they are TeamA! we need to swap values if we are TeamB (this was a funny one to figure out)
+            // Server side we already check if players are in TeamA or TeamB so we are fine
+            if (player.TeamId == Team.TeamB)
+            {
+                // Swap EnemyBans and FriendlyBans
+                (rankedResolutionPhaseDataClone.EnemyBans, rankedResolutionPhaseDataClone.FriendlyBans) =
+                    (rankedResolutionPhaseDataClone.FriendlyBans, rankedResolutionPhaseDataClone.EnemyBans);
+
+                // Swap EnemyTeamSelections and FriendlyTeamSelections
+                (rankedResolutionPhaseDataClone.EnemyTeamSelections, rankedResolutionPhaseDataClone.FriendlyTeamSelections) =
+                    (rankedResolutionPhaseDataClone.FriendlyTeamSelections, rankedResolutionPhaseDataClone.EnemyTeamSelections);
+            }
+
+            c.Send(new EnterFreelancerResolutionPhaseNotification()
+            {
+                SubPhase = PhaseSubType,
+                RankedData = rankedResolutionPhaseDataClone,
+            });
+        });
     }
 }

--- a/LobbyServer2/BridgeServer/GameManager.cs
+++ b/LobbyServer2/BridgeServer/GameManager.cs
@@ -103,26 +103,6 @@ public class GameManager
         return null;
     }
 
-    public static Game GetGameWithPlayerDraft(long accountId)
-    {
-        foreach (Game game in Games.Values)
-        {
-            if (game.GameStatus is >= GameStatus.Started
-                && game.Server is { IsConnected: true })
-            {
-                foreach (long player in game.GetPlayers())
-                {
-                    if (player.Equals(accountId))
-                    {
-                        return game;
-                    }
-                }
-            }
-        }
-
-        return null;
-    }
-
     public static void ReconnectServer(BridgeServerProtocol server)
     {
         if (Games.TryGetValue(server.ProcessCode, out Game game))

--- a/LobbyServer2/BridgeServer/GameManager.cs
+++ b/LobbyServer2/BridgeServer/GameManager.cs
@@ -103,6 +103,26 @@ public class GameManager
         return null;
     }
 
+    public static Game GetGameWithPlayerDraft(long accountId)
+    {
+        foreach (Game game in Games.Values)
+        {
+            if (game.GameStatus is >= GameStatus.Started
+                && game.Server is { IsConnected: true })
+            {
+                foreach (long player in game.GetPlayers())
+                {
+                    if (player.Equals(accountId))
+                    {
+                        return game;
+                    }
+                }
+            }
+        }
+
+        return null;
+    }
+
     public static void ReconnectServer(BridgeServerProtocol server)
     {
         if (Games.TryGetValue(server.ProcessCode, out Game game))

--- a/LobbyServer2/BridgeServer/PvpGame.cs
+++ b/LobbyServer2/BridgeServer/PvpGame.cs
@@ -37,11 +37,13 @@ public class PvpGame: Game
         SetGameStatus(GameStatus.FreelancerSelecting);
         GetClients().ForEach(client => SendGameAssignmentNotification(client));
 
+        await HandleRankedResolutionPhase();
+
         // Check for duplicated and WillFill characters
         if (CheckDuplicatedAndFill())
         {
             // Wait for Freelancer selection time
-            TimeSpan timeout = GameInfo.SelectTimeout;
+            TimeSpan timeout = GameSubType.Mods.Contains(GameSubType.SubTypeMods.RankedFreelancerSelection) ? TimeSpan.Zero : GameInfo.SelectTimeout;
             TimeSpan timePassed = TimeSpan.Zero;
             bool allReady = false;
 
@@ -126,6 +128,10 @@ public class PvpGame: Game
             AcceptTimeout = new TimeSpan(0, 0, 0),
             SelectTimeout = TimeSpan.FromSeconds(30),
             LoadoutSelectTimeout = TimeSpan.FromSeconds(30),
+            SelectSubPhaseBan1Timeout = TimeSpan.FromSeconds(60),
+            SelectSubPhaseBan2Timeout = TimeSpan.FromSeconds(30),
+            SelectSubPhaseFreelancerSelectTimeout = TimeSpan.FromSeconds(30),
+            SelectSubPhaseTradeTimeout = TimeSpan.FromSeconds(30),
             ActiveHumanPlayers = TeamInfo.TeamPlayerInfo.Count(p => p.IsHumanControlled),
             ActivePlayers = TeamInfo.TeamPlayerInfo.Count,
             CreateTimestamp = DateTime.UtcNow.Ticks,

--- a/LobbyServer2/CentralServer.csproj
+++ b/LobbyServer2/CentralServer.csproj
@@ -11,6 +11,7 @@
     <PackageReference Include="Discord.Net.WebSocket" Version="3.10.0" />
     <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="7.0.7" />
     <PackageReference Include="Microsoft.Extensions.Logging.Log4Net.AspNetCore" Version="6.1.0" />
+    <PackageReference Include="morelinq" Version="4.3.0" />
     <PackageReference Include="prometheus-net.AspNetCore" Version="8.2.1" />
     <PackageReference Include="System.ServiceModel.Primitives" Version="4.9.0" />
   </ItemGroup>

--- a/LobbyServer2/Config/GameSubTypes/Custom.json
+++ b/LobbyServer2/Config/GameSubTypes/Custom.json
@@ -64,7 +64,7 @@
     }
   },
   {
-    "LocalizedName": "Tournament_Draft_Bans@GameWideData", // Add in client patch
+    "LocalizedName": "Tournament_Draft_Bans@GameWideData",
     "GameMapConfigs": [
       {
         "Map": "Skyway_Deathmatch",
@@ -130,7 +130,7 @@
     }
   },
   {
-    "LocalizedName": "Tournament_Draft_NoBans@GameWideData", // Add in client patch
+    "LocalizedName": "Tournament_Draft_NoBans@GameWideData",
     "GameMapConfigs": [
       {
         "Map": "Skyway_Deathmatch",
@@ -196,7 +196,7 @@
     }
   },
   {
-    "LocalizedName": "Tournament_NoDraft@GameWideData", // Add in client patch
+    "LocalizedName": "Tournament_NoDraft@GameWideData",
     "GameMapConfigs": [
       {
         "Map": "Skyway_Deathmatch",
@@ -261,7 +261,7 @@
     }
   },
   {
-    "LocalizedName": "Draft_Bans@GameWideData", // Add in client patch
+    "LocalizedName": "RankedCustom@SubTypes",
     "GameMapConfigs": [
       {
         "Map": "Skyway_Deathmatch",
@@ -327,7 +327,7 @@
     }
   },
   {
-    "LocalizedName": "Draft_NoBans@GameWideData", // Add in client patch
+    "LocalizedName": "Draft_NoBans@GameWideData",
     "GameMapConfigs": [
       {
         "Map": "Skyway_Deathmatch",

--- a/LobbyServer2/Config/GameSubTypes/Custom.json
+++ b/LobbyServer2/Config/GameSubTypes/Custom.json
@@ -64,7 +64,7 @@
     }
   },
   {
-    "LocalizedName": "PlayerTitle_47_Unlock_1_Condition@GameWideData",
+    "LocalizedName": "Tournament_Draft_Bans@GameWideData", // Add in client patch
     "GameMapConfigs": [
       {
         "Map": "Skyway_Deathmatch",
@@ -95,8 +95,8 @@
         "IsActive": true
       }
     ],
-    "TeamAPlayers": 1,
-    "TeamBPlayers": 1,
+    "TeamAPlayers": 4,
+    "TeamBPlayers": 4,
     "TeamABots": 0,
     "TeamBBots": 0,
     "TeamComposition": {
@@ -119,6 +119,270 @@
     },
     "RewardBucket": "NoRewards",
     "PersistedStatBucket": "DoNotPersist",
+    "Bans": true,
+    "Mods": [
+      "AllowPlayingLockedCharacters",
+      "HumansHaveFirstSlots",
+      "RankedFreelancerSelection"
+    ],
+    "GameOverrides": {
+      "TurnTimeSpan": "00:00:20"
+    }
+  },
+  {
+    "LocalizedName": "Tournament_Draft_NoBans@GameWideData", // Add in client patch
+    "GameMapConfigs": [
+      {
+        "Map": "Skyway_Deathmatch",
+        "IsActive": true
+      },
+      {
+        "Map": "CargoShip_Deathmatch",
+        "IsActive": true
+      },
+      {
+        "Map": "Casino01_Deathmatch",
+        "IsActive": true
+      },
+      {
+        "Map": "EvosLab_Deathmatch",
+        "IsActive": true
+      },
+      {
+        "Map": "Oblivion_Deathmatch",
+        "IsActive": true
+      },
+      {
+        "Map": "Reactor_Deathmatch",
+        "IsActive": true
+      },
+      {
+        "Map": "RobotFactory_Deathmatch",
+        "IsActive": true
+      }
+    ],
+    "TeamAPlayers": 4,
+    "TeamBPlayers": 4,
+    "TeamABots": 0,
+    "TeamBBots": 0,
+    "TeamComposition": {
+      "Rules": {
+        "A1": {
+          "Roles": [
+            "Tank",
+            "Assassin",
+            "Support"
+          ]
+        },
+        "B1": {
+          "Roles": [
+            "Tank",
+            "Assassin",
+            "Support"
+          ]
+        }
+      }
+    },
+    "RewardBucket": "NoRewards",
+    "PersistedStatBucket": "DoNotPersist",
+    "Bans": false,
+    "Mods": [
+      "AllowPlayingLockedCharacters",
+      "HumansHaveFirstSlots",
+      "RankedFreelancerSelection"
+    ],
+    "GameOverrides": {
+      "TurnTimeSpan": "00:00:20"
+    }
+  },
+  {
+    "LocalizedName": "Tournament_NoDraft@GameWideData", // Add in client patch
+    "GameMapConfigs": [
+      {
+        "Map": "Skyway_Deathmatch",
+        "IsActive": true
+      },
+      {
+        "Map": "CargoShip_Deathmatch",
+        "IsActive": true
+      },
+      {
+        "Map": "Casino01_Deathmatch",
+        "IsActive": true
+      },
+      {
+        "Map": "EvosLab_Deathmatch",
+        "IsActive": true
+      },
+      {
+        "Map": "Oblivion_Deathmatch",
+        "IsActive": true
+      },
+      {
+        "Map": "Reactor_Deathmatch",
+        "IsActive": true
+      },
+      {
+        "Map": "RobotFactory_Deathmatch",
+        "IsActive": true
+      }
+    ],
+    "TeamAPlayers": 4,
+    "TeamBPlayers": 4,
+    "TeamABots": 0,
+    "TeamBBots": 0,
+    "TeamComposition": {
+      "Rules": {
+        "A1": {
+          "Roles": [
+            "Tank",
+            "Assassin",
+            "Support"
+          ]
+        },
+        "B1": {
+          "Roles": [
+            "Tank",
+            "Assassin",
+            "Support"
+          ]
+        }
+      }
+    },
+    "RewardBucket": "NoRewards",
+    "PersistedStatBucket": "DoNotPersist",
+    "Bans": false,
+    "Mods": [
+      "AllowPlayingLockedCharacters",
+      "HumansHaveFirstSlots"
+    ],
+    "GameOverrides": {
+      "TurnTimeSpan": "00:00:20"
+    }
+  },
+  {
+    "LocalizedName": "Draft_Bans@GameWideData", // Add in client patch
+    "GameMapConfigs": [
+      {
+        "Map": "Skyway_Deathmatch",
+        "IsActive": true
+      },
+      {
+        "Map": "CargoShip_Deathmatch",
+        "IsActive": true
+      },
+      {
+        "Map": "Casino01_Deathmatch",
+        "IsActive": true
+      },
+      {
+        "Map": "EvosLab_Deathmatch",
+        "IsActive": true
+      },
+      {
+        "Map": "Oblivion_Deathmatch",
+        "IsActive": true
+      },
+      {
+        "Map": "Reactor_Deathmatch",
+        "IsActive": true
+      },
+      {
+        "Map": "RobotFactory_Deathmatch",
+        "IsActive": true
+      }
+    ],
+    "TeamAPlayers": 4,
+    "TeamBPlayers": 4,
+    "TeamABots": 0,
+    "TeamBBots": 0,
+    "TeamComposition": {
+      "Rules": {
+        "A1": {
+          "Roles": [
+            "Tank",
+            "Assassin",
+            "Support"
+          ]
+        },
+        "B1": {
+          "Roles": [
+            "Tank",
+            "Assassin",
+            "Support"
+          ]
+        }
+      }
+    },
+    "RewardBucket": "NoRewards",
+    "PersistedStatBucket": "DoNotPersist",
+    "Bans": true,
+    "Mods": [
+      "AllowPlayingLockedCharacters",
+      "HumansHaveFirstSlots",
+      "RankedFreelancerSelection"
+    ],
+    "GameOverrides": {
+      "TurnTimeSpan": "00:00:20"
+    }
+  },
+  {
+    "LocalizedName": "Draft_NoBans@GameWideData", // Add in client patch
+    "GameMapConfigs": [
+      {
+        "Map": "Skyway_Deathmatch",
+        "IsActive": true
+      },
+      {
+        "Map": "CargoShip_Deathmatch",
+        "IsActive": true
+      },
+      {
+        "Map": "Casino01_Deathmatch",
+        "IsActive": true
+      },
+      {
+        "Map": "EvosLab_Deathmatch",
+        "IsActive": true
+      },
+      {
+        "Map": "Oblivion_Deathmatch",
+        "IsActive": true
+      },
+      {
+        "Map": "Reactor_Deathmatch",
+        "IsActive": true
+      },
+      {
+        "Map": "RobotFactory_Deathmatch",
+        "IsActive": true
+      }
+    ],
+    "TeamAPlayers": 4,
+    "TeamBPlayers": 4,
+    "TeamABots": 0,
+    "TeamBBots": 0,
+    "TeamComposition": {
+      "Rules": {
+        "A1": {
+          "Roles": [
+            "Tank",
+            "Assassin",
+            "Support"
+          ]
+        },
+        "B1": {
+          "Roles": [
+            "Tank",
+            "Assassin",
+            "Support"
+          ]
+        }
+      }
+    },
+    "RewardBucket": "NoRewards",
+    "PersistedStatBucket": "DoNotPersist",
+    "Bans": false,
     "Mods": [
       "AllowPlayingLockedCharacters",
       "HumansHaveFirstSlots",

--- a/LobbyServer2/Config/GameSubTypes/DeathMatch.json
+++ b/LobbyServer2/Config/GameSubTypes/DeathMatch.json
@@ -31,8 +31,8 @@
         "IsActive": true
       }
     ],
-    "TeamAPlayers": 1,
-    "TeamBPlayers": 1,
+    "TeamAPlayers": 4,
+    "TeamBPlayers": 4,
     "TeamABots": 0,
     "TeamBBots": 0,
     "TeamComposition": {
@@ -55,9 +55,11 @@
     },
     "RewardBucket": "NoRewards",
     "PersistedStatBucket": "DoNotPersist",
+    "Bans": true,
     "Mods": [
       "AllowPlayingLockedCharacters",
-      "HumansHaveFirstSlots"
+      "HumansHaveFirstSlots",
+      "RankedFreelancerSelection"
     ],
     "GameOverrides": {
       "TurnTimeSpan": "00:00:20"

--- a/LobbyServer2/Config/defaultEquip.json
+++ b/LobbyServer2/Config/defaultEquip.json
@@ -251,5 +251,19 @@
     "ModForAbility2": -1,
     "ModForAbility3": -1,
     "ModForAbility4": -1
+  },
+  "TestFreelancer1": {
+    "ModForAbility0": -1,
+    "ModForAbility1": -1,
+    "ModForAbility2": -1,
+    "ModForAbility3": -1,
+    "ModForAbility4": -1
+  },
+  "TestFreelancer2": {
+    "ModForAbility0": -1,
+    "ModForAbility1": -1,
+    "ModForAbility2": -1,
+    "ModForAbility3": -1,
+    "ModForAbility4": -1
   }
 }

--- a/LobbyServer2/LobbyServer/CustomGames/CustomGame.cs
+++ b/LobbyServer2/LobbyServer/CustomGames/CustomGame.cs
@@ -40,6 +40,10 @@ public class CustomGame : Game
             AcceptTimeout = new TimeSpan(0, 0, 0),
             SelectTimeout = TimeSpan.FromSeconds(30),
             LoadoutSelectTimeout = TimeSpan.FromSeconds(30),
+            SelectSubPhaseBan1Timeout = TimeSpan.FromSeconds(60),
+            SelectSubPhaseBan2Timeout = TimeSpan.FromSeconds(30),
+            SelectSubPhaseFreelancerSelectTimeout = TimeSpan.FromSeconds(30),
+            SelectSubPhaseTradeTimeout = TimeSpan.FromSeconds(30),
             ActiveHumanPlayers = GroupManager.GetPlayerGroup(accountId).Members.Count,
             ActivePlayers = GroupManager.GetPlayerGroup(accountId).Members.Count,
             CreateTimestamp = DateTime.UtcNow.Ticks,
@@ -539,6 +543,8 @@ public class CustomGame : Game
         SetGameStatus(GameStatus.FreelancerSelecting);
         GetClients().ForEach(client => SendGameAssignmentNotification(client));
 
+        await HandleRankedResolutionPhase();
+
         SetGameStatus(GameStatus.LoadoutSelecting);
 
         if (!CheckIfAllParticipantsAreConnected())
@@ -678,6 +684,10 @@ public class CustomGame : Game
         GameInfo = gameinfo.Clone();
         GameInfo.ActivePlayers = TeamInfo.TeamPlayerInfo.Count;
         GameInfo.LoadoutSelectTimeout = TimeSpan.FromSeconds(30);
+        GameInfo.SelectSubPhaseBan1Timeout = TimeSpan.FromSeconds(60);
+        GameInfo.SelectSubPhaseBan2Timeout = TimeSpan.FromSeconds(30);
+        GameInfo.SelectSubPhaseFreelancerSelectTimeout = TimeSpan.FromSeconds(30);
+        GameInfo.SelectSubPhaseTradeTimeout = TimeSpan.FromSeconds(30);
         GameInfo.AcceptedPlayers = TeamInfo.TeamPlayerInfo.Count;
         GameInfo.ActiveHumanPlayers = TeamInfo.TeamPlayerInfo.Count(p => p.IsHumanControlled);
         GameInfo.GameConfig.TeamAPlayers = TeamInfo.TeamAPlayerInfo.Count();

--- a/LobbyServer2/LobbyServer/LobbyServerProtocol.cs
+++ b/LobbyServer2/LobbyServer/LobbyServerProtocol.cs
@@ -616,7 +616,9 @@ namespace CentralServer.LobbyServer
                     Send(new ChatNotification
                     {
                         ConsoleMessageType = ConsoleMessageType.SystemMessage,
-                        Text = "Controlling characters is not allowed in this mode. use DeathMatch or Tournament No Draft mode for this, Normal bots are allowed however"
+                        Text = "Controlling multiple characters is not allowed in this mode. "
+                               + "If you want to control multiple characters, please select Deathmatch mode. "
+                               + "Normal bots are allowed, however."
                     });
                     return;
                 }

--- a/LobbyServer2/LobbyServer/LobbyServerProtocol.cs
+++ b/LobbyServer2/LobbyServer/LobbyServerProtocol.cs
@@ -270,11 +270,7 @@ namespace CentralServer.LobbyServer
                 || characterType == CharacterType.TestFreelancer2)
             {
                 // Build a list of all used character types for use with Fill
-                List<CharacterType> usedCharacterTypes = new();
-                usedCharacterTypes.AddRange(rankedResolutionPhaseData.FriendlyBans);
-                usedCharacterTypes.AddRange(rankedResolutionPhaseData.EnemyBans);
-                usedCharacterTypes.AddRange(rankedResolutionPhaseData.FriendlyTeamSelections.Values);
-                usedCharacterTypes.AddRange(rankedResolutionPhaseData.EnemyTeamSelections.Values);
+                HashSet<CharacterType> usedCharacterTypes = CurrentGame.GetUsedCharacterTypes();
                 characterType = CurrentGame.AssignRandomCharacterForDraft(player, usedCharacterTypes, characterType);
             }
 
@@ -355,11 +351,7 @@ namespace CentralServer.LobbyServer
                     || characterType == CharacterType.TestFreelancer2)
                 {
                     // Build a list of all used character types for use with Fill
-                    List<CharacterType> usedCharacterTypes = new();
-                    usedCharacterTypes.AddRange(rankedResolutionPhaseData.FriendlyBans);
-                    usedCharacterTypes.AddRange(rankedResolutionPhaseData.EnemyBans);
-                    usedCharacterTypes.AddRange(rankedResolutionPhaseData.FriendlyTeamSelections.Values);
-                    usedCharacterTypes.AddRange(rankedResolutionPhaseData.EnemyTeamSelections.Values);
+                    HashSet<CharacterType> usedCharacterTypes = CurrentGame.GetUsedCharacterTypes();
                     characterType = CurrentGame.AssignRandomCharacterForDraft(player, usedCharacterTypes, characterType);
                 }
 

--- a/LobbyServer2/LobbyServer/Matchmaking/MatchmakingManager.cs
+++ b/LobbyServer2/LobbyServer/Matchmaking/MatchmakingManager.cs
@@ -7,6 +7,7 @@ using CentralServer.LobbyServer.Session;
 using EvoS.Framework.Network.NetworkMessages;
 using EvoS.Framework.Network.Static;
 using log4net;
+using static MoreLinq.Extensions.ShuffleExtension;
 
 namespace CentralServer.LobbyServer.Matchmaking
 {
@@ -226,7 +227,7 @@ namespace CentralServer.LobbyServer.Matchmaking
                 log.Info($"Failed to create {gameType} game");
                 return;
             }
-            await game.StartGameAsync(teamA, teamB, gameType, gameSubTypes, subTypeIndex);
+            await game.StartGameAsync(teamA.Shuffle().ToList(), teamB.Shuffle().ToList(), gameType, gameSubTypes, subTypeIndex);
         }
 
         public static void OnGameEnded(LobbyGameInfo gameInfo, LobbyGameSummary gameSummary)

--- a/LobbyServer2/LobbyServer/Matchmaking/QueuePenaltyManager.cs
+++ b/LobbyServer2/LobbyServer/Matchmaking/QueuePenaltyManager.cs
@@ -39,6 +39,11 @@ public static class QueuePenaltyManager
             {
                 return;
             }
+            if (game.GameStatus < GameStatus.Started) {
+                //Left in Draft, punish harder, no leaving Draft cause they dont like the map or the Draft
+                SetQueuePenalty(accountId, GameType.PvP, TimeSpan.FromMinutes(10));
+                return;
+            }
             if (game.GameStatus != GameStatus.Stopped)
             {
                 SetQueuePenalty(accountId, GameType.PvP, TimeSpan.FromSeconds(200));

--- a/LobbyServer2/LobbyServer/Matchmaking/QueuePenaltyManager.cs
+++ b/LobbyServer2/LobbyServer/Matchmaking/QueuePenaltyManager.cs
@@ -39,7 +39,8 @@ public static class QueuePenaltyManager
             {
                 return;
             }
-            if (game.GameStatus < GameStatus.Started) {
+            if (game.IsDraft && game.GameStatus < GameStatus.Started)
+            {
                 //Left in Draft, punish harder, no leaving Draft cause they dont like the map or the Draft
                 SetQueuePenalty(accountId, GameType.PvP, TimeSpan.FromMinutes(10));
                 return;

--- a/LobbyServer2/LobbyServer/Stats/StatsApi.cs
+++ b/LobbyServer2/LobbyServer/Stats/StatsApi.cs
@@ -100,7 +100,10 @@ namespace CentralServer.LobbyServer.Stats
                 {
                     foreach (GameSubType subType in gameInfo.GameConfig.SubTypes)
                     {
-                        if (subType.Mods != null && subType.Mods.Contains(SubTypeMods.RankedFreelancerSelection))
+                        if (subType.LocalizedName != null && 
+                            (subType.LocalizedName == "Tournament_Draft_Bans@GameWideData"
+                              || subType.LocalizedName == "Tournament_Draft_NoBans@GameWideData")
+                              || subType.LocalizedName == "Tournament_NoDraft@GameWideData")
                         {
                             gameType = "Tournament";
                         }

--- a/LobbyServer2/LobbyServer/Stats/StatsApi.cs
+++ b/LobbyServer2/LobbyServer/Stats/StatsApi.cs
@@ -96,20 +96,20 @@ namespace CentralServer.LobbyServer.Stats
                 string map = Maps.GetMapName[gameInfo.GameConfig.Map];
                 string gameType = gameInfo.GameConfig.GameType.ToString();
 
-                if (gameInfo.GameConfig.SelectedSubType.Mods != null)
+                GameSubType subType = gameInfo.GameConfig.SelectedSubType;
+                if (subType.Mods != null)
                 {
-                    if (gameInfo.GameConfig.SelectedSubType.Mods.Contains(SubTypeMods.RankedFreelancerSelection)
+                    if (subType.Mods.Contains(SubTypeMods.RankedFreelancerSelection)
                         && gameInfo.GameConfig.GameType == GameType.Custom)
                     {
-                        if (subType.LocalizedName != null && 
-                            (subType.LocalizedName == "Tournament_Draft_Bans@GameWideData"
-                              || subType.LocalizedName == "Tournament_Draft_NoBans@GameWideData")
-                              || subType.LocalizedName == "Tournament_NoDraft@GameWideData")
+                        if (subType.LocalizedName == "Tournament_Draft_Bans@GameWideData"
+                            || subType.LocalizedName == "Tournament_Draft_NoBans@GameWideData"
+                            || subType.LocalizedName == "Tournament_NoDraft@GameWideData")
                         {
                             gameType = "Tournament";
                         }
                     }
-                    if (gameInfo.GameConfig.SelectedSubType.Mods.Contains(SubTypeMods.ControlAllBots)
+                    if (subType.Mods.Contains(SubTypeMods.ControlAllBots)
                         && gameInfo.GameConfig.GameType != GameType.Custom)
                     {
                         gameType = "FourLancer";


### PR DESCRIPTION
Some important rules for Draft Mode:

Character Selection:
Players must select a character. If not, the game will end.

Leaver Penalty:
Leaving the game or going AFK will now result in a harsher punishment: a 10-minute ban, even for AFK. This is because the Draft phase takes time, and leaving wastes players' time, which could lead to frustration. Those who dodge will not be able to requeue for 10 minutes, and this timer will not be pardoned.

Bots:
Bots work in draft, will random pick a character its just random they do not try to make a full op team, much like bots are now Draft will NOT work with controlling characters, Sorry no 4lancher Draft, this proberbly will never be in the game as it requires Client patch and cannot be compatible with Vanilla, if you try to add a Controlling bot, list will reset and remove all bots and warns you in chat

Draft Mode Details:

Random Selection:
Players can choose a random character from one of three categories: Firepower, Frontline, or Support. This feature is currently available only to players using the beta version of the game, but it will be available in the stable version soon. If you don't have the beta version, you cannot select a random character, but you can still participate in Draft mode as normal.

Map Preview & Team Picks:
In Draft mode, players can see the map beforehand and pick their character based on the map and team composition. You can also see what the opposing team picks. However, you can only select your character when it’s your turn in the order, and the other team will also be able to see your picks.

Character Trades:
You can trade Freelancers with your teammates during the Draft phase.

Timers in Draft are
First ban = 60s
Second Ban = 30s
Selecting Freelancer = 30s
Trade = 30s

Custom:
Added 5new game modes
Tournament Draft With Bans
Tournament Draft No Bans
Tournament No Draft
Draft With Bans
Draft With No Bans
(needs beta for loc to work proper)

Technical Details
Added CharacterType.TestFreelancer1 and CharacterType.TestFreelancer2 these (and CharacterType.PendingWillFill) are used in Draft (only) to know what category a player selects for random, they do not show up anywhere else, they do in bot selection but they are disabled anyway 
Updated PatchAccount to add missing freelancers and add default mods that game requeres 
Punish players harder if GameStatus < GameStatus.Started (if we notice that players abuse it this way to avoid the big punish i will ban them for 7days) 
Added 5new game modes in Custom (needs client patch for names to be correct) 
In GameSubTypes json's to add Draft add the Mod "RankedFreelancerSelection" 
there is a new Key '"Bans": true,' means bans are enabled if its not set or its False Draft has no bans 
Update StatsApi to work with the new LocalizedNames thats Specify its a Tournament or not 
Should not happen! but if we have a dupicate or a fill in the game force them to change but set DUPLICATE_FREELANCER subphase to 0s they cannot change it for them self let us do it