### PR TITLE
Fix punishing players if leaving draft

### DIFF
--- a/LobbyServer2/BridgeServer/Game.cs
+++ b/LobbyServer2/BridgeServer/Game.cs
@@ -1236,7 +1236,7 @@ public abstract class Game
                 {
                     // Cancel Match AFK Player
                     CancelMatch(player.Handle);
-                    // TODO: Punish Player
+                    QueuePenaltyManager.IssueQueuePenalties(player.AccountId, this);
                     return;
                 }
                 // Selected is when did not lock in or clicked ban button


### PR DESCRIPTION
Set ban to 5mins instead
moved up isDraft higher in chain doesnt really matter it already checks if its PvP game or not higher if its not PvP it does nothing anyway